### PR TITLE
Replace homepage carousel with responsive gallery grid and enhance nav/visual styles

### DIFF
--- a/holboo/index.html
+++ b/holboo/index.html
@@ -202,6 +202,15 @@
 
 .phone-big:hover { color: #C8A96A !important; }
 
+.phone-big--secondary {
+  font-size: 1.1rem;
+  color: #9A9A90;
+}
+
+.req { color: #FF6B6B; }
+
+.inline-link { color: #C8A96A; }
+
 /* Social proof box */
 .proof-box {
   margin-top: 2rem;
@@ -562,15 +571,15 @@
   <a href="/" class="nav-logo" aria-label="NOMAAD Camp">
     <img src="/nomaad-logo-light.svg" alt="NOMAAD" class="nav-logo-word" width="148" height="35">
   </a>
-  <div class="nav-links">
+  <div class="nav-links" id="primary-nav">
     <a href="/">Нүүр</a>
     <a href="/kemp/">Кемп</a>
     <a href="/premium/">Premium</a>
     <a href="/holboo/" class="active">Холбоо барих</a>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem">
+  <div class="nav-actions">
     <a class="nav-cta" href="/holboo/">Үнийн санал авах</a>
-    <button class="nav-toggle" aria-label="Цэс">
+    <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
       </svg>
@@ -612,7 +621,7 @@
     <div class="c-info-block">
       <span class="c-info-label">Утас</span>
       <a href="tel:+97699179417" class="phone-big">9917-9417</a>
-      <a href="tel:+97688028216" class="phone-big" style="font-size:1.1rem;color:#9A9A90;">8802-8216</a>
+      <a href="tel:+97688028216" class="phone-big phone-big--secondary">8802-8216</a>
     </div>
 
     <div class="c-info-block">
@@ -665,12 +674,12 @@
 
       <div class="form-row-2">
         <div class="f-field" id="field-org">
-          <label for="org">Байгууллагын нэр <span style="color:#FF6B6B">*</span></label>
+          <label for="org">Байгууллагын нэр <span class="req">*</span></label>
           <input id="org" name="org" type="text" placeholder="XYZ ХХК" autocomplete="organization">
           <div class="field-error">Байгууллагын нэрийг бөглөнө үү</div>
         </div>
         <div class="f-field" id="field-contact">
-          <label for="contact">Холбоо барих хүн <span style="color:#FF6B6B">*</span></label>
+          <label for="contact">Холбоо барих хүн <span class="req">*</span></label>
           <input id="contact" name="contact" type="text" placeholder="Овог Нэр" autocomplete="name">
           <div class="field-error">Нэрийг бөглөнө үү</div>
         </div>
@@ -678,7 +687,7 @@
 
       <div class="form-row-2">
         <div class="f-field" id="field-email">
-          <label for="email">Имэйл хаяг <span style="color:#FF6B6B">*</span></label>
+          <label for="email">Имэйл хаяг <span class="req">*</span></label>
           <input id="email" name="email" type="email" placeholder="hr@company.mn" autocomplete="email">
           <div class="field-error">Зөв имэйл хаяг оруулна уу</div>
         </div>
@@ -689,16 +698,16 @@
       </div>
 
       <!-- Арга хэмжээ -->
-      <div class="form-section-title" style="margin-top:1.5rem">Арга хэмжээний мэдээлэл</div>
+      <div class="form-section-title">Арга хэмжээний мэдээлэл</div>
 
       <div class="form-row-2">
         <div class="f-field" id="field-people">
-          <label for="people">Хүний тоо <span style="color:#FF6B6B">*</span></label>
+          <label for="people">Хүний тоо <span class="req">*</span></label>
           <input id="people" name="people" type="number" min="10" max="1000" placeholder="Жишээ: 150" oninput="updateEstimate()">
           <div class="field-error">Хүний тоог оруулна уу (10–1000)</div>
         </div>
         <div class="f-field">
-          <label for="event_date">Хүссэн огноо <span style="color:#FF6B6B">*</span></label>
+          <label for="event_date">Хүссэн огноо <span class="req">*</span></label>
           <input id="event_date" name="event_date" type="date">
         </div>
       </div>
@@ -728,7 +737,7 @@
       </div>
 
       <!-- Багц -->
-      <div class="form-section-title" style="margin-top:1.5rem">Багц сонгох</div>
+      <div class="form-section-title">Багц сонгох</div>
 
       <div class="pkg-grid">
         <div class="pkg-card" id="pkg-basic" onclick="selectPkg('basic')">
@@ -781,7 +790,7 @@
         <div class="success-title">Амжилттай илгээгдлээ</div>
         <p class="success-sub">
           Ажлын 24 цагт таны имэйлд үнийн санал хүргэнэ.<br>
-          Яаралтай бол <a href="tel:+97699179417" style="color:#C8A96A">9917-9417</a> дугаарт залгаарай.
+          Яаралтай бол <a href="tel:+97699179417" class="inline-link">9917-9417</a> дугаарт залгаарай.
         </p>
       </div>
 
@@ -815,8 +824,8 @@
       </div>
       <div>
         <h5>Байршил</h5>
-        <p style="color:var(--muted);font-size:0.85rem">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
-        <p style="color:var(--muted);font-size:0.85rem;margin-top:0.75rem">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорий 1-13,<br>NOMAAD OFFICE</p>
+        <p class="footer-meta">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
+        <p class="footer-meta footer-meta--spaced">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорий 1-13,<br>NOMAAD OFFICE</p>
       </div>
       <div class="footer-cta">
         <h5>Холбоо барих</h5>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <a href="/" class="nav-logo" aria-label="NOMAAD Camp">
     <img src="nomaad-logo-light.svg" alt="NOMAAD" class="nav-logo-word" width="148" height="35">
   </a>
-  <div class="nav-links">
+  <div class="nav-links" id="primary-nav">
     <a href="/">Нүүр</a>
     <a href="/kemp/">Кемп</a>
     <a href="/premium/">Premium</a>
@@ -28,7 +28,7 @@
   </div>
   <div class="nav-actions">
     <a class="nav-cta" href="/holboo/">Үнийн санал авах</a>
-    <button class="nav-toggle" aria-label="Цэс">
+    <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
       </svg>
@@ -119,7 +119,7 @@
 </section>
 
 <!-- CAROUSEL -->
-<section class="section" style="padding-top:0">
+<section class="section section--flush-top">
   <div class="container">
     <div class="section-head reveal">
       <span class="eyebrow">Галерей</span>
@@ -145,7 +145,7 @@
     <span class="eyebrow">Байгальд суурилсан</span>
     <h2>Нэг зэрэгт 1,000 хүн — асуудалгүй.</h2>
     <p>42kVA/380V найдвартай эрчим хүч, орчин үеийн ариун цэвэр, 1,500м² асар. Байгууллагын баяр, нээлтийн арга хэмжээ, хамт олны аялал — бүгд нэг талбайд.</p>
-    <a class="btn btn--sand btn--lg" href="/kemp/" style="margin-top:2rem">Кемп үзэх</a>
+    <a class="btn btn--sand btn--lg u-mt-2" href="/kemp/">Кемп үзэх</a>
   </div>
 </section>
 
@@ -197,8 +197,8 @@
       </div>
       <div>
         <h5>Байршил</h5>
-        <p style="color:var(--muted);font-size:0.85rem">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
-        <p style="color:var(--muted);font-size:0.85rem;margin-top:0.75rem">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
+        <p class="footer-meta">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
+        <p class="footer-meta footer-meta--spaced">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
       </div>
       <div class="footer-cta">
         <h5>Холбоо барих</h5>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <a href="/premium/">Premium</a>
     <a href="/holboo/">Холбоо барих</a>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem">
+  <div class="nav-actions">
     <a class="nav-cta" href="/holboo/">Үнийн санал авах</a>
     <button class="nav-toggle" aria-label="Цэс">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
@@ -125,21 +125,13 @@
       <span class="eyebrow">Галерей</span>
       <h2>Бодит орчин.</h2>
     </div>
-    <div class="carousel reveal" data-carousel data-autoplay="false">
-      <div class="carousel-track">
-        <div class="carousel-slide"><img src="/gallery-01.jpg" alt="NOMAAD кемпийн орчин" loading="lazy"></div>
-        <div class="carousel-slide"><img src="/gallery-02.jpg" alt="Асар дотроос" loading="lazy"></div>
-        <div class="carousel-slide"><img src="/gallery-03.jpg" alt="Байгалийн орчин" loading="lazy"></div>
-        <div class="carousel-slide"><img src="/gallery-04.jpg" alt="Хоолны бүс" loading="lazy"></div>
-        <div class="carousel-slide"><img src="/gallery-05.jpg" alt="Үдшийн гэрэлтүүлэг" loading="lazy"></div>
-      </div>
-      <button class="carousel-arrow carousel-arrow--prev" type="button" aria-label="Өмнөх">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-      </button>
-      <button class="carousel-arrow carousel-arrow--next" type="button" aria-label="Дараах">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
-      </button>
-      <div class="carousel-dots" role="tablist"></div>
+    <div class="gallery-grid reveal">
+      <figure class="gallery-card gallery-card--wide"><img src="/gallery-01.jpg" alt="NOMAAD кемпийн төв талбай" loading="lazy"></figure>
+      <figure class="gallery-card"><img src="/gallery-02.jpg" alt="Асар доторх уур амьсгал" loading="lazy"></figure>
+      <figure class="gallery-card"><img src="/gallery-03.jpg" alt="Байгалийн ногоон орчин" loading="lazy"></figure>
+      <figure class="gallery-card gallery-card--tall"><img src="/gallery-04.jpg" alt="Хоолны үйлчилгээний бүс" loading="lazy"></figure>
+      <figure class="gallery-card"><img src="/gallery-05.jpg" alt="Оройн гэрэлтүүлэгтэй тайз" loading="lazy"></figure>
+      <figure class="gallery-card gallery-card--wide"><img src="/gallery-06.jpg" alt="Багаар ажиллах хөтөлбөр" loading="lazy"></figure>
     </div>
   </div>
 </section>

--- a/kemp/index.html
+++ b/kemp/index.html
@@ -19,15 +19,15 @@
   <a href="/" class="nav-logo" aria-label="NOMAAD Camp">
     <img src="/nomaad-logo-light.svg" alt="NOMAAD" class="nav-logo-word" width="148" height="35">
   </a>
-  <div class="nav-links">
+  <div class="nav-links" id="primary-nav">
     <a href="/">Нүүр</a>
     <a href="/kemp/">Кемп</a>
     <a href="/premium/">Premium</a>
     <a href="/holboo/">Холбоо барих</a>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem">
+  <div class="nav-actions">
     <a class="nav-cta" href="/holboo/">Үнийн санал авах</a>
-    <button class="nav-toggle" aria-label="Цэс">
+    <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
       </svg>
@@ -114,7 +114,7 @@
 </section>
 
 <!-- PRICE -->
-<section class="section" style="padding-top:0">
+<section class="section section--flush-top">
   <div class="container">
     <div class="price-block reveal">
       <div>
@@ -128,7 +128,7 @@
 </section>
 
 <!-- CAROUSEL -->
-<section class="section" style="padding-top:0">
+<section class="section section--flush-top">
   <div class="container">
     <div class="section-head reveal">
       <span class="eyebrow">Галерей</span>
@@ -184,8 +184,8 @@
       </div>
       <div>
         <h5>Байршил</h5>
-        <p style="color:var(--muted);font-size:0.85rem">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
-        <p style="color:var(--muted);font-size:0.85rem;margin-top:0.75rem">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
+        <p class="footer-meta">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
+        <p class="footer-meta footer-meta--spaced">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
       </div>
       <div class="footer-cta">
         <h5>Холбоо барих</h5>

--- a/main.js
+++ b/main.js
@@ -9,9 +9,22 @@
     navToggle.addEventListener('click', () => {
       nav.classList.toggle('is-open');
     });
+    document.addEventListener('click', (e) => {
+      if (!nav.classList.contains('is-open')) return;
+      if (!nav.contains(e.target)) nav.classList.remove('is-open');
+    });
     document.querySelectorAll('.nav-links a').forEach((a) => {
       a.addEventListener('click', () => nav.classList.remove('is-open'));
     });
+  }
+
+  // Sticky nav төлөв
+  if (nav) {
+    const onScroll = () => {
+      nav.classList.toggle('is-scrolled', window.scrollY > 12);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
   }
 
   // Идэвхтэй nav холбоос

--- a/main.js
+++ b/main.js
@@ -5,17 +5,31 @@
   // Мобайл nav toggle
   const nav = document.querySelector('.nav');
   const navToggle = document.querySelector('.nav-toggle');
+  const navMenu = nav ? nav.querySelector('.nav-links') : null;
   if (nav && navToggle) {
+    const setMenuOpen = (isOpen) => {
+      nav.classList.toggle('is-open', isOpen);
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+      document.body.classList.toggle('menu-open', isOpen);
+    };
+
     navToggle.addEventListener('click', () => {
-      nav.classList.toggle('is-open');
+      setMenuOpen(!nav.classList.contains('is-open'));
     });
     document.addEventListener('click', (e) => {
       if (!nav.classList.contains('is-open')) return;
-      if (!nav.contains(e.target)) nav.classList.remove('is-open');
+      if (!nav.contains(e.target)) setMenuOpen(false);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && nav.classList.contains('is-open')) {
+        setMenuOpen(false);
+        navToggle.focus();
+      }
     });
     document.querySelectorAll('.nav-links a').forEach((a) => {
-      a.addEventListener('click', () => nav.classList.remove('is-open'));
+      a.addEventListener('click', () => setMenuOpen(false));
     });
+    if (navMenu && !navMenu.id) navMenu.id = 'primary-nav';
   }
 
   // Sticky nav төлөв

--- a/premium/index.html
+++ b/premium/index.html
@@ -19,15 +19,15 @@
   <a href="/" class="nav-logo" aria-label="NOMAAD Camp">
     <img src="/nomaad-logo-light.svg" alt="NOMAAD" class="nav-logo-word" width="148" height="35">
   </a>
-  <div class="nav-links">
+  <div class="nav-links" id="primary-nav">
     <a href="/">Нүүр</a>
     <a href="/kemp/">Кемп</a>
     <a href="/premium/">Premium</a>
     <a href="/holboo/">Холбоо барих</a>
   </div>
-  <div style="display:flex;align-items:center;gap:0.75rem">
+  <div class="nav-actions">
     <a class="nav-cta" href="/holboo/">Үнийн санал авах</a>
-    <button class="nav-toggle" aria-label="Цэс">
+    <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
       </svg>
@@ -69,7 +69,7 @@
 </section>
 
 <!-- SPLIT -->
-<section class="section" style="padding-top:0">
+<section class="section section--flush-top">
   <div class="container">
     <div class="split reveal">
       <div class="split-media">
@@ -116,7 +116,7 @@
 </section>
 
 <!-- CAROUSEL -->
-<section class="section" style="padding-top:0">
+<section class="section section--flush-top">
   <div class="container">
     <div class="section-head reveal">
       <span class="eyebrow">Галерей</span>
@@ -170,8 +170,8 @@
       </div>
       <div>
         <h5>Байршил</h5>
-        <p style="color:var(--muted);font-size:0.85rem">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
-        <p style="color:var(--muted);font-size:0.85rem;margin-top:0.75rem">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
+        <p class="footer-meta">Эрдэнэ сум, Төв аймаг<br>УБ-аас 75 км</p>
+        <p class="footer-meta footer-meta--spaced">Оффис: БЗД, 11-р хороо,<br>Ногоон зоорь 1-13,<br>NOMAAD OFFICE</p>
       </div>
       <div class="footer-cta">
         <h5>Холбоо барих</h5>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@
   --nav-h:       76px;
   --container:   1240px;
   --ease:        cubic-bezier(0.22, 1, 0.36, 1);
+  --radius:      14px;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -50,19 +51,19 @@ h1, h2, h3, h4, h5 {
   color: var(--text);
 }
 h1 {
-  font-size: 48px;
+  font-size: clamp(2rem, 4.6vw, 3.4rem);
   font-weight: 600;
   letter-spacing: -0.025em;
   line-height: 1.15;
 }
 h2 {
-  font-size: 28px;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
   font-weight: 500;
   letter-spacing: -0.02em;
   line-height: 1.25;
 }
 h3 {
-  font-size: 20px;
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.35;
@@ -96,7 +97,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   padding: 0 2rem;
 }
 .section {
-  padding: 96px 0;
+  padding: clamp(4.2rem, 8vw, 6rem) 0;
   position: relative;
 }
 .section--tight { padding: 64px 0; }
@@ -118,7 +119,11 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   backdrop-filter: blur(18px) saturate(1.4);
   -webkit-backdrop-filter: blur(18px) saturate(1.4);
   border-bottom: 1px solid rgba(245, 245, 240, 0.15);
-  transition: background 0.25s var(--ease), border-color 0.25s var(--ease);
+  transition: background 0.25s var(--ease), border-color 0.25s var(--ease), box-shadow 0.25s var(--ease);
+}
+.nav.is-scrolled {
+  background: rgba(11, 13, 11, 0.88);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.26);
 }
 .nav-logo {
   display: inline-flex;
@@ -148,11 +153,16 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 }
 .nav-links a:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
 .nav-links a.active { color: var(--text); background: var(--surface-2); }
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
 .nav-cta {
   display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem;
   background: var(--text); color: var(--bg);
   padding: 14px 28px;
-  border-radius: 6px;
+  border-radius: 999px;
   font-size: 0.9rem; font-weight: 600;
   letter-spacing: 0.005em;
   transition: filter 0.2s var(--ease), background 0.2s var(--ease), color 0.2s var(--ease);
@@ -169,7 +179,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem;
   padding: 14px 28px;
-  border-radius: 6px;
+  border-radius: 999px;
   font-family: 'Inter', sans-serif;
   font-weight: 600;
   font-size: 0.95rem;
@@ -301,7 +311,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 /* ── HERO ── */
 .hero {
   position: relative;
-  min-height: 92vh;
+  min-height: min(92vh, 860px);
   display: flex; align-items: center;
   padding: calc(var(--nav-h) + 3rem) 0 5rem;
   overflow: hidden;
@@ -335,7 +345,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 }
 .hero-inner {
   position: relative; z-index: 2;
-  max-width: 960px;
+  max-width: 880px;
 }
 .hero h1 {
   margin-top: 0.25rem;
@@ -349,7 +359,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 .hero-sub {
   font-size: clamp(1.02rem, 1.25vw, 1.18rem);
   color: rgba(242, 241, 236, 0.78);
-  margin: 1.5rem 0 2.25rem;
+  margin: 1.25rem 0 2rem;
   max-width: 620px;
   line-height: 1.7;
   font-weight: 400;
@@ -512,7 +522,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   position: relative;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: var(--radius);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -818,94 +828,31 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   opacity: 0.7;
 }
 
-/* ── CAROUSEL ── */
-.carousel {
-  position: relative;
-  width: 100%;
-  height: 520px;
-  border-radius: 22px;
+/* ── GALLERY GRID ── */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+.gallery-card {
+  grid-column: span 4;
+  border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--line);
   background: var(--surface-2);
-  user-select: none;
-  touch-action: pan-y;
+  min-height: 220px;
 }
-.carousel-track {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  transition: transform 0.3s var(--ease);
-  will-change: transform;
-}
-.carousel-slide {
-  flex: 0 0 100%;
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-.carousel-slide img {
+.gallery-card--wide { grid-column: span 8; }
+.gallery-card--tall { grid-row: span 2; min-height: 460px; }
+.gallery-card img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  display: block;
-  pointer-events: none;
+  transition: transform 0.45s var(--ease), filter 0.45s var(--ease);
 }
-.carousel-arrow {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 44px;
-  height: 44px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.78);
-  color: #0B0D0B;
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 3;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  transition: background 0.2s var(--ease), transform 0.2s var(--ease), opacity 0.2s var(--ease);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
-}
-.carousel-arrow:hover { background: rgba(255, 255, 255, 0.95); }
-.carousel-arrow:active { transform: translateY(-50%) scale(0.96); }
-.carousel-arrow svg { width: 20px; height: 20px; }
-.carousel-arrow--prev { left: 16px; }
-.carousel-arrow--next { right: 16px; }
-.carousel-dots {
-  position: absolute;
-  left: 0; right: 0;
-  bottom: 18px;
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-  z-index: 3;
-}
-.carousel-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  border: none;
-  background: rgba(255, 255, 255, 0.45);
-  cursor: pointer;
-  padding: 0;
-  transition: background 0.2s var(--ease), transform 0.2s var(--ease), width 0.2s var(--ease);
-}
-.carousel-dot:hover { background: rgba(255, 255, 255, 0.7); }
-.carousel-dot.is-active {
-  background: #fff;
-  width: 22px;
-}
-@media (max-width: 768px) {
-  .carousel { height: 280px; border-radius: 16px; }
-  .carousel-arrow { width: 38px; height: 38px; }
-  .carousel-arrow--prev { left: 10px; }
-  .carousel-arrow--next { right: 10px; }
-  .carousel-arrow svg { width: 18px; height: 18px; }
-  .carousel-dots { bottom: 12px; }
+.gallery-card:hover img {
+  transform: scale(1.04);
+  filter: saturate(1.08);
 }
 
 /* ── REVEAL ANIMATIONS ── */
@@ -928,7 +875,11 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
     gap: 0.3rem;
   }
   .nav.is-open .nav-links a { padding: 0.8rem 1rem; font-size: 0.98rem; min-height: 44px; display: flex; align-items: center; }
-  .nav .nav-cta { display: none; }
+  .nav .nav-cta {
+    display: inline-flex;
+    padding: 0.66rem 0.95rem;
+    font-size: 0.78rem;
+  }
 
   .capacity { grid-template-columns: 1fr; }
   .feat-grid { grid-template-columns: 1fr; }
@@ -939,12 +890,16 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   .price-block { grid-template-columns: 1fr; text-align: left; }
   .footer-top { grid-template-columns: 1fr 1fr; }
   .bottom-cta { display: flex; }
+  .gallery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .gallery-card,
+  .gallery-card--wide,
+  .gallery-card--tall { grid-column: auto; grid-row: auto; min-height: 210px; }
 }
 @media (max-width: 768px) {
-  h1 { font-size: 32px; }
-  h2 { font-size: 22px; }
-  h3 { font-size: 18px; }
-  .page-header h1 { font-size: 32px; }
+  h1 { font-size: clamp(1.8rem, 8vw, 2.4rem); line-height: 1.2; }
+  h2 { font-size: clamp(1.35rem, 6vw, 1.8rem); }
+  h3 { font-size: 1.08rem; }
+  .page-header h1 { font-size: clamp(1.9rem, 8vw, 2.45rem); }
   .section { padding: 64px 0; }
   .section--tight { padding: 48px 0; }
 
@@ -953,13 +908,27 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   .hero-actions { flex-direction: column; align-items: stretch; }
   .hero-actions .btn { width: 100%; }
   .btn { width: 100%; }
-  .nav-cta { width: auto; }
+  .nav-cta { width: auto; white-space: nowrap; }
+  .nav-actions { gap: 0.35rem; }
+  .nav .nav-cta { padding: 0.62rem 0.85rem; font-size: 0.74rem; }
   .bottom-cta .btn { width: auto; }
   .feat-link { width: auto; }
+  .hero-meta { gap: 0.45rem; font-size: 0.74rem; letter-spacing: 0.02em; }
+  .section-head { margin-bottom: 2rem; }
+  .feat-body { padding: 1.35rem 1.1rem 1.5rem; }
+  .split-body p { font-size: 0.95rem; }
+  .gallery-grid { grid-template-columns: 1fr; gap: 0.8rem; }
+  .gallery-card,
+  .gallery-card--wide,
+  .gallery-card--tall { min-height: 200px; }
 }
 @media (max-width: 560px) {
   .container { padding: 0 1.25rem; }
   .nav { padding: 0 1.25rem; }
-  .hero { min-height: auto; padding: calc(var(--nav-h) + 3rem) 0 4rem; }
+  .hero { min-height: auto; padding: calc(var(--nav-h) + 2.4rem) 0 3.2rem; }
+  .hero-sub { margin: 1rem 0 1.4rem; font-size: 0.95rem; }
+  .eyebrow { font-size: 0.66rem; letter-spacing: 0.16em; }
+  .nav-logo-word { height: 15px; }
+  .nav .nav-cta { display: none; }
   .footer-top { grid-template-columns: 1fr; gap: 2rem; }
 }

--- a/style.css
+++ b/style.css
@@ -37,6 +37,7 @@ body {
   font-weight: 400;
   overflow-x: hidden;
 }
+body.menu-open { overflow: hidden; }
 img { max-width: 100%; display: block; }
 a { color: inherit; text-decoration: none; }
 button { font: inherit; }
@@ -101,6 +102,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   position: relative;
 }
 .section--tight { padding: 64px 0; }
+.section--flush-top { padding-top: 0; }
 .section-head { max-width: 760px; margin-bottom: 3rem; }
 .section-head p {
   font-size: clamp(1rem, 1.2vw, 1.08rem);
@@ -797,6 +799,11 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   letter-spacing: 0.04em;
 }
 .footer-brand { max-width: 360px; }
+.footer-meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.footer-meta--spaced { margin-top: 0.75rem; }
 .footer-logo {
   display: inline-flex;
   align-items: center;
@@ -827,6 +834,9 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
   background: var(--forest-2);
   opacity: 0.7;
 }
+
+/* ── UTILITIES ── */
+.u-mt-2 { margin-top: 2rem; }
 
 /* ── GALLERY GRID ── */
 .gallery-grid {


### PR DESCRIPTION
### Motivation
- Replace the JS-driven carousel with a simpler, responsive gallery to improve layout stability and mobile behavior.
- Improve mobile navigation UX by allowing the menu to close when clicking outside and making the nav visually stick on scroll.
- Harmonize spacing, radii, and responsive typography for a more consistent visual system across breakpoints.

### Description
- Updated `index.html` to replace the carousel markup with a semantic `.gallery-grid` of `<figure>` cards and introduced a `.nav-actions` wrapper for CTA and toggle controls.
- Extended `main.js` to close the mobile nav on outside clicks and added a scroll listener that toggles the `is-scrolled` class on the `.nav` element.
- Modified `style.css` to add `--radius`, switch to responsive font sizing via `clamp()`, introduce `.gallery-grid` / `.gallery-card` styles (replacing carousel CSS), add `.nav.is-scrolled` visual state, and refactor several spacing and radius values for buttons and cards.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac895a428832183537f0f40933bb2)