### PR TITLE
fix: update all CTA links to use #contact anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <a href="#contact">Холбоо барих</a>
   </div>
   <div class="nav-actions">
-    <a class="nav-cta" href="/holboo/#quoteForm">Үнийн санал авах</a>
+    <a class="nav-cta" href="#contact">Үнийн санал авах</a>
     <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
@@ -81,7 +81,7 @@
     <h1>Зөвхөн танай байгууллагад зориулсан<br>кемпийн бүрэн шийдэл</h1>
     <p class="hero-sub">NOMAAD кемп нь байгууллагын арга хэмжээ, багийн идэвхжүүлэлт, удирдлагын уулзалт болон том хэмжээний эвентүүдийг төлөвлөлтөөс гүйцэтгэл хүртэл нэгдсэн байдлаар хэрэгжүүлдэг.</p>
     <div class="hero-actions">
-      <a class="btn btn--accent btn--lg" href="/holboo/#quoteForm">Үнийн санал авах</a>
+      <a class="btn btn--accent btn--lg" href="#contact">Үнийн санал авах</a>
       <a class="btn btn--ghost-light btn--lg" href="#camps">Кемпүүд үзэх</a>
     </div>
 
@@ -161,7 +161,7 @@
         <div class="camp-detail-text">
           <h3>C Кемп · 10–50 хүн</h3>
           <p>Удирдлагын баг, шийдвэр гаргах уулзалт, төвлөрсөн ажлын хөтөлбөрт тохирсон тайван орчин.</p>
-          <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+          <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
         </div>
         <div class="camp-detail-media" data-carousel data-autoplay="false">
           <div class="carousel-track">
@@ -179,7 +179,7 @@
         <div class="camp-detail-text">
           <h3>B Кемп · 50–300 хүн</h3>
           <p>Баг, алба нэгжийн уялдаа, дотоод соёл, сургалтын хөтөлбөрийг нэгдсэн зохион байгуулалтаар хэрэгжүүлнэ.</p>
-          <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+          <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
         </div>
         <div class="camp-detail-media" data-carousel data-autoplay="false">
           <div class="carousel-track">
@@ -197,7 +197,7 @@
         <div class="camp-detail-text">
           <h3>A Кемп · 200–1000 хүн</h3>
           <p>Том хэмжээний байгууллагын ойн баяр, өдөрлөг, олон оролцогчтой арга хэмжээг найдвартай зохион байгуулна.</p>
-          <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+          <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
         </div>
         <div class="camp-detail-media" data-carousel data-autoplay="false">
           <div class="carousel-track">
@@ -215,7 +215,7 @@
         <div class="camp-detail-text">
           <h3>Нүүдлийн кемп · Хүссэн байршилд</h3>
           <p>Танай сонгосон байршилд талбай, техник, хоол, хөтөлбөрийн бүрэн зохион байгуулалтыг уян хатан хүргэнэ.</p>
-          <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+          <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
         </div>
         <div class="camp-detail-media" data-carousel data-autoplay="false">
           <div class="carousel-track">
@@ -310,14 +310,14 @@
   <div class="container reveal">
     <h2>Танай байгууллагад тохирсон арга хэмжээг хамтдаа зохион байгуулъя</h2>
     <p>Хүний тоо, огноо, зорилгын мэдээллээ илгээнэ үү. Манай баг 24 цагийн дотор үнийн санал боловсруулж холбогдоно.</p>
-    <a class="btn btn--accent btn--lg" href="/holboo/#quoteForm">Үнийн санал авах</a>
+    <a class="btn btn--accent btn--lg" href="#contact">Үнийн санал авах</a>
   </div>
 </section>
 </main>
 
 <div class="bottom-cta">
   <a class="phone" href="tel:+97699179417">9917-9417</a>
-  <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+  <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
 </div>
 
 <footer class="footer">
@@ -348,7 +348,7 @@
       <div class="footer-cta">
         <h3 class="footer-title">Холбоо барих</h3>
         <a href="tel:+97699179417" class="phone">9917-9417</a>
-        <a class="btn btn--accent" href="/holboo/#quoteForm">Үнийн санал авах</a>
+        <a class="btn btn--accent" href="#contact">Үнийн санал авах</a>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #21

All "Үнийн санал авах" CTA links in index.html now point to href="#contact" instead of /holboo/#quoteForm. The contact section already had id="contact", so no structural changes were needed.

Generated with [Claude Code](https://claude.ai/code)