### PR TITLE
fix: improve mobile layout and readability on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -1233,9 +1233,12 @@ body.home-page .footer .footer-tagline::before {
 @media (max-width: 760px) {
   .exp-grid,
   .process-grid,
-  .pillars,
   .trust-grid {
     grid-template-columns: 1fr;
+  }
+  .pillars {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.7rem;
   }
 
   .hero--corporate {
@@ -1280,7 +1283,6 @@ body.home-page .footer .footer-tagline::before {
   body.home-page .section {
     padding: 3.6rem 0;
   }
-}
 }
 
 /* ── Homepage camp cards + detail ── */
@@ -1420,6 +1422,24 @@ body.home-page .footer .footer-tagline::before {
   .hero--corporate {
     min-height: 76vh;
     padding-top: calc(var(--nav-h) + 1.4rem);
+  }
+  .camp-detail {
+    padding: 0.75rem;
+    gap: 0.75rem;
+  }
+  .camp-detail-media .carousel-slide {
+    height: 180px;
+  }
+  .pillar {
+    font-size: 0.9rem;
+    padding: 0.8rem 0.9rem;
+  }
+  .process-grid li,
+  .exp-card {
+    padding: 1rem;
+  }
+  .bottom-cta {
+    padding-bottom: max(0.85rem, calc(0.85rem + env(safe-area-inset-bottom, 0px)));
   }
 }
 /* === HERO TEXT FIX (FINAL - DO NOT EDIT ABOVE CODE) === */


### PR DESCRIPTION
Fixes mobile layout issues and improves readability on small screens.

Changes:
- Remove stray CSS closing brace (parse bug)
- Keep pillars section at 2-column on mobile for better scannability
- Tighten camp detail card padding on 560px screens
- Reduce carousel slide height at 560px to prevent awkward cropping
- Add iOS safe-area-inset-bottom to sticky bottom CTA bar

Closes #22

Generated with [Claude Code](https://claude.ai/code)