### PR TITLE
Make .reveal elements visible by default (remove hidden initial state)

### DIFF
--- a/style.css
+++ b/style.css
@@ -887,7 +887,7 @@ p  { color: var(--muted); font-size: 16px; line-height: 1.6; }
 
 /* ── REVEAL ANIMATIONS ── */
 .reveal {
-  opacity: 0; transform: translateY(24px);
+  opacity: 1; transform: translateY(0);
   transition: opacity 0.8s var(--ease), transform 0.8s var(--ease);
 }
 .reveal.is-visible { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
### Motivation
- The `.reveal` selector previously set `opacity: 0` and a downward translate, which hid content until animations/JS ran, so the change ensures content is visible by default for accessibility and layout consistency.

### Description
- Updated the `.reveal` rule from `opacity: 0; transform: translateY(24px);` to `opacity: 1; transform: translateY(0);`, keeping the transition intact so elements remain animatable.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb126f38348321abca3816d3311e29)