### PR TITLE
Adjust homepage dark-section and CTA text color for improved contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -1068,6 +1068,12 @@ body.home-page .nav-cta {
 .section--dark h3,
 .section--dark li,
 .section--dark .pillar { color: var(--text-light); }
+body.home-page .section--dark h2,
+body.home-page .section--dark p,
+body.home-page .section--dark .eyebrow,
+body.home-page .section--dark h3,
+body.home-page .section--dark li,
+body.home-page .section--dark .pillar { color: rgba(255, 255, 255, 0.96); }
 
 .trust-grid {
   display: grid;
@@ -1157,6 +1163,8 @@ body.home-page .gallery-card {
 }
 .cta-final h2,
 .cta-final p { color: var(--text-light); }
+body.home-page .cta-final h2,
+body.home-page .cta-final p { color: rgba(255, 255, 255, 0.96); }
 .cta-final p { max-width: 720px; margin: 0.8rem auto 1.6rem; }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
### Motivation
- Ensure text within dark sections and the final CTA on the homepage has a consistent near-white color for improved legibility and visual consistency.

### Description
- Added more specific selectors `body.home-page .section--dark h2, p, .eyebrow, h3, li, .pillar` to set `color: rgba(255, 255, 255, 0.96)` overriding the generic `var(--text-light)` on the homepage.
- Added `body.home-page .cta-final h2, body.home-page .cta-final p` with `color: rgba(255, 255, 255, 0.96)` to ensure the CTA text matches the updated contrast.
- No layout, sizing, or behavioral changes were made; this is a visual/style-only update in `style.css`.

### Testing
- Ran the project's style linter (`stylelint`) against the modified CSS and it passed.
- Ran the frontend build and test suite (`npm test`) and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb126f38348321abca3816d3311e29)