### PR TITLE
fix: quote modal responsive fix (issue #55)

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,62 +184,6 @@
     deferredImages.forEach(loadImage);
   }
 
-  // data-src зурагт fallback (хуучин deploy/cached HTML нийцүүлэлт)
-  const deferredImages = document.querySelectorAll('img.defer-img[data-src]');
-  if (deferredImages.length > 0) {
-    const loadImage = (img) => {
-      const src = img.getAttribute('data-src');
-      if (!src) return;
-      img.setAttribute('src', src);
-      img.removeAttribute('data-src');
-      img.classList.remove('defer-img');
-    };
-    if ('IntersectionObserver' in window) {
-      const imageObs = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              loadImage(entry.target);
-              imageObs.unobserve(entry.target);
-            }
-          });
-        },
-        { rootMargin: '220px 0px' }
-      );
-      deferredImages.forEach((img) => imageObs.observe(img));
-    } else {
-      deferredImages.forEach(loadImage);
-    }
-  }
-
-  // data-src зурагт fallback (хуучин deploy/cached HTML нийцүүлэлт)
-  const deferredImages = document.querySelectorAll('img.defer-img[data-src]');
-  if (deferredImages.length > 0) {
-    const loadImage = (img) => {
-      const src = img.getAttribute('data-src');
-      if (!src) return;
-      img.setAttribute('src', src);
-      img.removeAttribute('data-src');
-      img.classList.remove('defer-img');
-    };
-    if ('IntersectionObserver' in window) {
-      const imageObs = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              loadImage(entry.target);
-              imageObs.unobserve(entry.target);
-            }
-          });
-        },
-        { rootMargin: '220px 0px' }
-      );
-      deferredImages.forEach((img) => imageObs.observe(img));
-    } else {
-      deferredImages.forEach(loadImage);
-    }
-  }
-
   // Carousel
   document.querySelectorAll('[data-carousel]').forEach((root) => {
     const track = root.querySelector('.carousel-track');

--- a/style.css
+++ b/style.css
@@ -1287,11 +1287,13 @@ body.modal-open { overflow: hidden; }
   place-items: center;
   padding: 1rem;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
-  transition: opacity 0.2s var(--ease);
+  transition: opacity 0.2s var(--ease), visibility 0.2s var(--ease);
 }
 .quote-modal.is-open {
   opacity: 1;
+  visibility: visible;
   pointer-events: auto;
 }
 .quote-modal__backdrop {
@@ -1302,25 +1304,33 @@ body.modal-open { overflow: hidden; }
 .quote-modal__dialog {
   position: relative;
   width: min(680px, 96vw);
-  max-height: min(86vh, 860px);
-  overflow: auto;
+  max-height: min(88vh, 860px);
+  overflow-y: auto;
+  overflow-x: hidden;
   background: var(--cream);
   border-radius: 14px;
   border: 1px solid rgba(31, 42, 35, 0.16);
   box-shadow: 0 18px 40px rgba(9, 12, 10, 0.24);
-  padding: 1.15rem 1.15rem 1.2rem;
+  padding: 2.8rem 1.4rem 1.4rem;
 }
 .quote-modal__close {
   position: absolute;
-  top: 0.45rem;
+  top: 0.55rem;
   right: 0.55rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   background: transparent;
   color: var(--charcoal);
   font-size: 1.7rem;
   line-height: 1;
   cursor: pointer;
+  border-radius: 6px;
 }
+.quote-modal__close:hover { background: rgba(31, 42, 35, 0.08); }
 .quote-modal__dialog h2 {
   color: var(--charcoal);
   margin-bottom: 0.85rem;
@@ -1385,6 +1395,10 @@ body.modal-open { overflow: hidden; }
     grid-template-columns: 1fr;
   }
   .quote-form__grid { grid-template-columns: 1fr; }
+  .quote-modal { padding: 0.5rem; }
+  .quote-modal__dialog { padding: 2.6rem 1rem 1.2rem; border-radius: 10px; }
+  .quote-form input,
+  .quote-form textarea { padding: 0.75rem 0.85rem; font-size: 1rem; }
   .hero--corporate {
     min-height: 78vh;
     padding-top: calc(var(--nav-h) + 1.1rem);


### PR DESCRIPTION
Fixes #55

**Root cause:** Duplicate `const deferredImages` declarations in main.js caused a SyntaxError that prevented the entire script from running, including the modal initialization code.

**Changes:**
- Remove 56 lines of duplicated JS that caused the SyntaxError
- Add visibility toggle for accessibility
- Fix close button touch target (2.4rem × 2.4rem)
- Fix overflow-y/overflow-x on modal dialog
- Add mobile breakpoint overrides for 390px screens

Generated with [Claude Code](https://claude.ai/code)