### PR TITLE
Add Shuttle Service addon and quote-form enhancements; reorder camps and update package copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,12 +104,12 @@
     </div>
 
     <div class="camp-grid reveal">
-      <button class="camp-card is-active" type="button" data-camp-target="camp-c">
-        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="C кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="c">
+      <button class="camp-card is-active" type="button" data-camp-target="camp-a">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="A кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="a">
         <div class="camp-card-body">
-          <h3>C Кемп</h3>
-          <p class="camp-size">10–50 хүн</p>
-          <p>Цөөн хүний уулзалт, удирдлагын багт зориулсан төвлөрсөн, тухтай орчин.</p>
+          <h3>A Кемп</h3>
+          <p class="camp-size">200–1000 хүн</p>
+          <p>Том хэмжээний байгууллагын ой, спорт өдөрлөг, олон хүний арга хэмжээнд.</p>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-b">
@@ -120,12 +120,12 @@
           <p>Баг, алба нэгжийн аялал, сургалт, дотоод арга хэмжээнд тохирсон.</p>
         </div>
       </button>
-      <button class="camp-card" type="button" data-camp-target="camp-a">
-        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="A кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="a">
+      <button class="camp-card" type="button" data-camp-target="camp-c">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="C кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="c">
         <div class="camp-card-body">
-          <h3>A Кемп</h3>
-          <p class="camp-size">200–1000 хүн</p>
-          <p>Том хэмжээний байгууллагын ой, спорт өдөрлөг, олон хүний арга хэмжээнд.</p>
+          <h3>C Кемп</h3>
+          <p class="camp-size">10–50 хүн</p>
+          <p>Цөөн хүний уулзалт, удирдлагын багт зориулсан төвлөрсөн, тухтай орчин.</p>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-mobile">
@@ -139,7 +139,7 @@
     </div>
 
     <div class="camp-detail-wrap reveal">
-      <article class="camp-detail has-packages is-open" id="camp-c">
+      <article class="camp-detail has-packages" id="camp-c">
         <div class="camp-detail-text">
           <h3>C Кемп · 10–50 хүн</h3>
           <p>Удирдлагын баг, шийдвэр гаргах уулзалт, төвлөрсөн ажлын хөтөлбөрт тохирсон тайван орчин.</p>
@@ -157,7 +157,7 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
@@ -189,21 +189,31 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="pkg-addon-list" role="group" aria-label="Нэмэлт үйлчилгээ">
+          <label class="pkg-addon-option">
+            <input type="checkbox" name="addon_shuttle_c" value="Shuttle Service">
+            <span class="pkg-addon-option__title">Shuttle Service</span>
+            <span class="pkg-addon-option__meta">45 хүний автобус · УБ ↔ Кемп / 2 талдаа · +1,000,000₮</span>
+          </label>
         </div>
       </article>
 
@@ -225,7 +235,7 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
@@ -257,25 +267,35 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="pkg-addon-list" role="group" aria-label="Нэмэлт үйлчилгээ">
+          <label class="pkg-addon-option">
+            <input type="checkbox" name="addon_shuttle_b" value="Shuttle Service">
+            <span class="pkg-addon-option__title">Shuttle Service</span>
+            <span class="pkg-addon-option__meta">45 хүний автобус · УБ ↔ Кемп / 2 талдаа · +1,000,000₮</span>
+          </label>
         </div>
       </article>
 
-      <article class="camp-detail has-packages" id="camp-a">
+      <article class="camp-detail has-packages is-open" id="camp-a">
         <div class="camp-detail-text">
           <h3>A Кемп · 200–1000 хүн</h3>
           <p>Том хэмжээний байгууллагын ойн баяр, өдөрлөг, олон оролцогчтой арга хэмжээг найдвартай зохион байгуулна.</p>
@@ -293,7 +313,7 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
@@ -325,21 +345,31 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="pkg-addon-list" role="group" aria-label="Нэмэлт үйлчилгээ">
+          <label class="pkg-addon-option">
+            <input type="checkbox" name="addon_shuttle_a" value="Shuttle Service">
+            <span class="pkg-addon-option__title">Shuttle Service</span>
+            <span class="pkg-addon-option__meta">45 хүний автобус · УБ ↔ Кемп / 2 талдаа · +1,000,000₮</span>
+          </label>
         </div>
       </article>
 
@@ -361,7 +391,7 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
@@ -393,7 +423,7 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -401,13 +431,23 @@
               <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="pkg-addon-list" role="group" aria-label="Нэмэлт үйлчилгээ">
+          <label class="pkg-addon-option">
+            <input type="checkbox" name="addon_shuttle_mobile" value="Shuttle Service">
+            <span class="pkg-addon-option__title">Shuttle Service</span>
+            <span class="pkg-addon-option__meta">45 хүний автобус · УБ ↔ Кемп / 2 талдаа · +1,000,000₮</span>
+          </label>
         </div>
       </article>
     </div>
@@ -551,8 +591,12 @@
           <span class="quote-prefill__val" id="prefill-tier-val"></span>
         </div>
         <div class="quote-prefill__row" id="prefill-row-feature" hidden>
-          <span class="quote-prefill__key">Нэмэлт үйлчилгээ</span>
+          <span class="quote-prefill__key">Visual feature</span>
           <span class="quote-prefill__val" id="prefill-feature-val"></span>
+        </div>
+        <div class="quote-prefill__row" id="prefill-row-shuttle" hidden>
+          <span class="quote-prefill__key">Shuttle Service</span>
+          <span class="quote-prefill__val" id="prefill-shuttle-val"></span>
         </div>
         <input type="hidden" name="camp_name" id="field-camp-name">
         <input type="hidden" name="package_tier" id="field-package-tier">
@@ -576,8 +620,12 @@
           <input id="email" name="email" type="email" autocomplete="email">
         </div>
         <div class="quote-form__field">
-          <label for="event-date">Хүссэн огноо</label>
-          <input id="event-date" name="event_date" type="date" required>
+          <label for="start-datetime">Эхлэх огноо, цаг</label>
+          <input id="start-datetime" name="start_datetime" type="datetime-local" required>
+        </div>
+        <div class="quote-form__field">
+          <label for="end-datetime">Дуусах огноо, цаг</label>
+          <input id="end-datetime" name="end_datetime" type="datetime-local" required>
         </div>
         <div class="quote-form__field">
           <label for="guest-count">Хүний тоо</label>
@@ -585,7 +633,17 @@
         </div>
         <div class="quote-form__field quote-form__field--full">
           <label for="event-type">Арга хэмжээний төрөл</label>
-          <input id="event-type" name="event_type" type="text">
+          <select id="event-type" name="event_type">
+            <option value="">Сонгоно уу</option>
+            <option value="Байгууллагын аялал">Байгууллагын аялал</option>
+            <option value="Team building">Team building</option>
+            <option value="Retreat">Retreat</option>
+            <option value="Байгууллагын ой">Байгууллагын ой</option>
+            <option value="Сургалт / workshop">Сургалт / workshop</option>
+            <option value="VIP event">VIP event</option>
+            <option value="Festival / outdoor event">Festival / outdoor event</option>
+            <option value="Other">Other</option>
+          </select>
         </div>
         <div class="quote-form__field quote-form__field--full" id="location-field-wrap" hidden>
           <label for="location">Кемп байгуулах байршил <span class="quote-form__required" aria-hidden="true">*</span></label>
@@ -593,12 +651,21 @@
           <input id="location" name="location" type="text" placeholder="Жишээ: Архангай — Өгий нуур">
         </div>
         <div class="quote-form__field quote-form__field--full">
+          <label for="shuttle-service">Shuttle Service</label>
+          <select id="shuttle-service" name="shuttle_service">
+            <option value="Сонгохгүй">Сонгохгүй</option>
+            <option value="Өдрөөр / 2 талдаа — 1,000,000₮">Өдрөөр / 2 талдаа — 1,000,000₮</option>
+            <option value="Хоног / 2 талдаа — 1,200,000₮">Хоног / 2 талдаа — 1,200,000₮</option>
+          </select>
+          <small class="quote-form__helper-text">Shuttle Service нь зочдын тээвэрлэлтийн үйлчилгээ бөгөөд Нүүдлийн кемпийн логистикийн зардлаас тусдаа тооцогдоно.</small>
+        </div>
+        <div class="quote-form__field quote-form__field--full">
           <label for="extra-info">Нэмэлт мэдээлэл</label>
           <textarea id="extra-info" name="extra_info" rows="4"></textarea>
         </div>
       </div>
       <p class="quote-form__message" id="quote-form-message" aria-live="polite"></p>
-      <button class="btn btn--accent" type="submit">Илгээх</button>
+      <button class="btn btn--accent" type="submit">Урьдчилсан санал авах</button>
     </form>
   </div>
 </div>

--- a/main.js
+++ b/main.js
@@ -5,9 +5,9 @@
   // Future-ready config: add pricing when realtime estimation is ready
   var PACKAGE_CONFIG = {
     camps: {
-      'camp-c':      { name: 'C Кемп',         isMobile: false },
-      'camp-b':      { name: 'B Кемп',         isMobile: false },
       'camp-a':      { name: 'A Кемп',         isMobile: false },
+      'camp-b':      { name: 'B Кемп',         isMobile: false },
+      'camp-c':      { name: 'C Кемп',         isMobile: false },
       'camp-mobile': { name: 'Нүүдлийн кемп',  isMobile: true  }
     },
     tiers: {
@@ -18,7 +18,11 @@
     addons: {
       'LED Screen':     { price: null },
       'Moonbeam Lounge':{ price: null },
-      'Тайзны эффект':  { price: null }
+      'Тайзны эффект':  { price: null },
+      'Shuttle Service':{
+        price: 1000000,
+        description: '45 хүний автобус · УБ ↔ Кемп / 2 талдаа'
+      }
     }
   };
 
@@ -341,14 +345,33 @@
     const prefillCampRow = document.getElementById('prefill-row-camp');
     const prefillTierRow = document.getElementById('prefill-row-tier');
     const prefillFeatRow = document.getElementById('prefill-row-feature');
+    const prefillShuttleRow = document.getElementById('prefill-row-shuttle');
     const prefillCampVal = document.getElementById('prefill-camp-val');
     const prefillTierVal = document.getElementById('prefill-tier-val');
     const prefillFeatVal = document.getElementById('prefill-feature-val');
+    const prefillShuttleVal = document.getElementById('prefill-shuttle-val');
     const fieldCampName  = document.getElementById('field-camp-name');
     const fieldTier      = document.getElementById('field-package-tier');
     const fieldFeature   = document.getElementById('field-visual-feature');
     const locationWrap   = document.getElementById('location-field-wrap');
     const locationInput  = document.getElementById('location');
+    const shuttleServiceSelect = document.getElementById('shuttle-service');
+
+    const applyLocationVisibility = (camp) => {
+      var isMobile = camp === 'Нүүдлийн кемп';
+      if (locationWrap) locationWrap.hidden = !isMobile;
+      if (locationInput) {
+        locationInput.required = isMobile;
+        if (!isMobile) locationInput.value = '';
+      }
+    };
+
+    const collectSelectedAddons = (groupName) => {
+      if (!groupName) return [];
+      return Array.from(document.querySelectorAll('input[name="' + groupName + '"]:checked'))
+        .map((input) => input.value)
+        .filter(Boolean);
+    };
 
     const openQuoteModal = (prefill) => {
       quoteModal.classList.add('is-open');
@@ -359,20 +382,31 @@
         var camp    = (prefill && prefill.camp)    || '';
         var tier    = (prefill && prefill.tier)    || '';
         var feature = (prefill && prefill.feature) || '';
+        var addOns  = (prefill && prefill.addOns)  || [];
+        var shuttleService = (prefill && prefill.shuttleService) || 'Сонгохгүй';
 
         if (fieldCampName) fieldCampName.value = camp;
         if (fieldTier)     fieldTier.value     = tier;
         if (fieldFeature)  fieldFeature.value  = feature;
+        if (shuttleServiceSelect) shuttleServiceSelect.value = shuttleService;
 
-        var hasPrefill = !!(camp || tier || feature);
+        var hasPrefill = !!(camp || tier || feature || shuttleService !== 'Сонгохгүй');
         if (prefillBox)     prefillBox.hidden     = !hasPrefill;
         if (prefillCampRow) { prefillCampRow.hidden = !camp;    if (prefillCampVal) prefillCampVal.textContent = camp; }
         if (prefillTierRow) { prefillTierRow.hidden = !tier;    if (prefillTierVal) prefillTierVal.textContent = tier; }
         if (prefillFeatRow) { prefillFeatRow.hidden = !feature; if (prefillFeatVal) prefillFeatVal.textContent = feature; }
+        if (prefillShuttleRow) {
+          var showShuttle = shuttleService && shuttleService !== 'Сонгохгүй';
+          prefillShuttleRow.hidden = !showShuttle;
+          if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleService;
+        }
 
-        var isMobile = camp === 'Нүүдлийн кемп';
-        if (locationWrap)  locationWrap.hidden   = !isMobile;
-        if (locationInput) locationInput.required = isMobile;
+        if (addOns.indexOf('Shuttle Service') !== -1 && shuttleServiceSelect && shuttleServiceSelect.value === 'Сонгохгүй') {
+          shuttleServiceSelect.value = 'Өдрөөр / 2 талдаа — 1,000,000₮';
+          if (prefillShuttleRow) prefillShuttleRow.hidden = false;
+          if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleServiceSelect.value;
+        }
+        applyLocationVisibility(camp);
       }
 
       window.setTimeout(() => {
@@ -388,8 +422,8 @@
       if (fieldCampName) fieldCampName.value = '';
       if (fieldTier)     fieldTier.value     = '';
       if (fieldFeature)  fieldFeature.value  = '';
-      if (locationWrap)  locationWrap.hidden   = true;
-      if (locationInput) locationInput.required = false;
+      if (shuttleServiceSelect) shuttleServiceSelect.value = 'Сонгохгүй';
+      applyLocationVisibility('');
     };
 
     quoteOpeners.forEach((link) => {
@@ -398,14 +432,29 @@
         var campName    = (link.dataset.campName    || '').trim();
         var tier        = (link.dataset.tier        || '').trim();
         var visualGroup = (link.dataset.visualGroup || '').trim();
+        var addonGroup  = (link.dataset.addonGroup  || '').trim();
         var feature     = '';
         if (visualGroup) {
           var checked = document.querySelector('input[name="' + visualGroup + '"]:checked');
           feature = checked ? checked.value : '';
+          if (!feature) {
+            window.alert('Experience багцын нэмэлт үйлчилгээний 1 сонголт хийнэ үү.');
+            return;
+          }
         }
-        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature } : null);
+        var addOns = collectSelectedAddons(addonGroup);
+        var shuttlePrefill = addOns.indexOf('Shuttle Service') !== -1 ? 'Өдрөөр / 2 талдаа — 1,000,000₮' : 'Сонгохгүй';
+        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature, addOns: addOns, shuttleService: shuttlePrefill } : null);
       });
     });
+
+    if (shuttleServiceSelect) {
+      shuttleServiceSelect.addEventListener('change', () => {
+        var shuttleValue = shuttleServiceSelect.value || 'Сонгохгүй';
+        if (prefillShuttleRow) prefillShuttleRow.hidden = shuttleValue === 'Сонгохгүй';
+        if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleValue;
+      });
+    }
 
     closeTargets.forEach((el) => {
       el.addEventListener('click', () => closeQuoteModal());
@@ -445,18 +494,24 @@
       submitBtn.textContent = 'Илгээж байна…';
 
       const payload = {
+        camp:           (fd.get('camp_name')     || '').trim(),
+        tier:           (fd.get('package_tier')  || '').trim(),
+        visual_feature: (fd.get('visual_feature')|| '').trim(),
+        shuttle_service:(fd.get('shuttle_service') || '').trim(),
+        location:       ((fd.get('camp_name') || '').trim() === 'Нүүдлийн кемп') ? (fd.get('location') || '').trim() : '',
+        notes:          (fd.get('extra_info')    || '').trim(),
         company:        (fd.get('organization')  || '').trim(),
         contact_name:   (fd.get('contact_name')  || '').trim(),
         phone,
         email,
-        event_date:     (fd.get('event_date')    || '').trim(),
+        start_datetime: (fd.get('start_datetime')|| '').trim(),
+        end_datetime:   (fd.get('end_datetime')  || '').trim(),
+        event_date:     (fd.get('start_datetime')|| '').trim(),
         guest_count:    (fd.get('guest_count')   || '').trim(),
         event_type:     (fd.get('event_type')    || '').trim(),
-        location:       (fd.get('location')      || '').trim(),
         camp_name:      (fd.get('camp_name')     || '').trim(),
         package_tier:   (fd.get('package_tier')  || '').trim(),
-        visual_feature: (fd.get('visual_feature')|| '').trim(),
-        notes:          (fd.get('extra_info')    || '').trim(),
+        shuttle_service_label: (fd.get('shuttle_service') || '').trim(),
         source:         'nomaadcamp.com'
       };
 
@@ -476,7 +531,7 @@
         quoteMessage.className = 'quote-form__message quote-form__message--error';
       } finally {
         submitBtn.disabled = false;
-        submitBtn.textContent = 'Илгээх';
+        submitBtn.textContent = 'Урьдчилсан санал авах';
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -1352,6 +1352,7 @@ body.modal-open { overflow: hidden; }
   color: var(--charcoal);
 }
 .quote-form input,
+.quote-form select,
 .quote-form textarea {
   width: 100%;
   border: 1px solid rgba(31, 42, 35, 0.22);
@@ -1400,6 +1401,7 @@ body.modal-open { overflow: hidden; }
   .quote-modal { padding: 0.5rem; }
   .quote-modal__dialog { padding: 2.6rem 1rem 1.2rem; border-radius: 10px; }
   .quote-form input,
+  .quote-form select,
   .quote-form textarea { padding: 0.75rem 0.85rem; font-size: 1rem; }
   .hero--corporate {
     min-height: 78vh;
@@ -1913,6 +1915,36 @@ body.modal-open { overflow: hidden; }
   font-size: 0.78rem;
   color: rgba(26, 26, 26, 0.52);
   font-weight: 400;
+}
+
+.pkg-note {
+  margin-top: 0.45rem;
+  font-size: 0.76rem;
+  color: rgba(26, 26, 26, 0.6);
+  line-height: 1.45;
+}
+.pkg-addon-list {
+  margin-top: 0.85rem;
+}
+.pkg-addon-option {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid rgba(31, 42, 35, 0.15);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+  background: #fff;
+}
+.pkg-addon-option input {
+  margin: 0 0 0.25rem;
+}
+.pkg-addon-option__title {
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: var(--charcoal);
+}
+.pkg-addon-option__meta {
+  font-size: 0.78rem;
+  color: rgba(26, 26, 26, 0.65);
 }
 
 /* ── MOBILE CAMP NOTE ─────────────────────────────────────── */


### PR DESCRIPTION
### Motivation
- Introduce a selectable `Shuttle Service` addon for camp packages and expose it in the quote modal for better pricing/transport collection.
- Improve quote form UX by switching to datetime inputs, adding an `event_type` select, and showing/hiding location when `Нүүдлийн кемп` is selected.
- Reorder camp cards so the large `A Кемп` is the active/default and keep package/production copy consistent across camps.

### Description
- Updated `index.html` to swap camp card order and default active card, add `data-addon-group` attributes to package CTAs, change package price/production copy, add per-camp addon checkbox lists, add shuttle prefill row in the modal, replace `event_date` with `start_datetime`/`end_datetime`, replace `event_type` input with a `select`, and change the submit button label.
- Extended `main.js` to add a `Shuttle Service` entry in `PACKAGE_CONFIG.addons`, re-ordered `camps` keys, implemented `collectSelectedAddons` and `applyLocationVisibility`, integrated shuttle prefill handling and UI updates, enforce Experience visual selection, include `shuttle_service`/`shuttle_service_label` in the webhook payload, and update submit button text handling.
- Added styles in `style.css` for the modal `select`, `.pkg-note`, `.pkg-addon-list`, and `.pkg-addon-option` to style addon controls and helper copy, plus responsive tweaks for form elements.

### Testing
- No automated tests were available or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbc047784832182a7f12b86e594cf)