### PR TITLE
Camps: add shuttle addon, per-camp galleries, form datetime/select and UI/UX polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,12 +104,13 @@
     </div>
 
     <div class="camp-grid reveal">
-      <button class="camp-card is-active" type="button" data-camp-target="camp-c">
-        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="C кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="c">
+      <button class="camp-card" type="button" data-camp-target="camp-a">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="A кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="a">
         <div class="camp-card-body">
-          <h3>C Кемп</h3>
-          <p class="camp-size">10–50 хүн</p>
-          <p>Цөөн хүний уулзалт, удирдлагын багт зориулсан төвлөрсөн, тухтай орчин.</p>
+          <h3>A Кемп</h3>
+          <p class="camp-size">200–1000 хүн</p>
+          <p>Том хэмжээний байгууллагын ой, спорт өдөрлөг, олон хүний арга хэмжээнд.</p>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-b">
@@ -118,14 +119,16 @@
           <h3>B Кемп</h3>
           <p class="camp-size">50–300 хүн</p>
           <p>Баг, алба нэгжийн аялал, сургалт, дотоод арга хэмжээнд тохирсон.</p>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
-      <button class="camp-card" type="button" data-camp-target="camp-a">
-        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="A кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="a">
+      <button class="camp-card" type="button" data-camp-target="camp-c">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="C кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="c">
         <div class="camp-card-body">
-          <h3>A Кемп</h3>
-          <p class="camp-size">200–1000 хүн</p>
-          <p>Том хэмжээний байгууллагын ой, спорт өдөрлөг, олон хүний арга хэмжээнд.</p>
+          <h3>C Кемп</h3>
+          <p class="camp-size">10–50 хүн</p>
+          <p>Цөөн хүний уулзалт, удирдлагын багт зориулсан төвлөрсөн, тухтай орчин.</p>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-mobile">
@@ -134,12 +137,13 @@
           <h3>Нүүдлийн кемп</h3>
           <p class="camp-size">Хүссэн байршилд</p>
           <p>Танай байгууллагын сонгосон байршилд кемп зохион байгуулах уян хатан шийдэл.</p>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
     </div>
 
     <div class="camp-detail-wrap reveal">
-      <article class="camp-detail has-packages is-open" id="camp-c">
+      <article class="camp-detail has-packages" id="camp-c">
         <div class="camp-detail-text">
           <h3>C Кемп · 10–50 хүн</h3>
           <p>Удирдлагын баг, шийдвэр гаргах уулзалт, төвлөрсөн ажлын хөтөлбөрт тохирсон тайван орчин.</p>
@@ -157,10 +161,10 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
+            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">350,000₮<span class="pkg-per"> / хүн</span></div>
@@ -189,21 +193,35 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="camp-gallery" data-camp-gallery="c" aria-label="C Кемп зургийн цомог">
+          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__viewport">
+            <div class="camp-gallery__track"></div>
+            <div class="camp-gallery__empty" hidden>
+              <p>Зургийн цомог удахгүй нэмэгдэнэ.</p>
+              <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
+            </div>
+          </div>
+          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -225,10 +243,10 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
+            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -257,21 +275,35 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production" data-addon-group="addon_shuttle_b">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="camp-gallery" data-camp-gallery="b" aria-label="B Кемп зургийн цомог">
+          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__viewport">
+            <div class="camp-gallery__track"></div>
+            <div class="camp-gallery__empty" hidden>
+              <p>Зургийн цомог удахгүй нэмэгдэнэ.</p>
+              <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
+            </div>
+          </div>
+          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -293,10 +325,10 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
+            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -325,21 +357,35 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price pkg-price--custom">Тусгай санал</div>
+              <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="camp-gallery" data-camp-gallery="a" aria-label="A Кемп зургийн цомог">
+          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__viewport">
+            <div class="camp-gallery__track"></div>
+            <div class="camp-gallery__empty" hidden>
+              <p>Зургийн цомог удахгүй нэмэгдэнэ.</p>
+              <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
+            </div>
+          </div>
+          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -361,10 +407,10 @@
               <li>Тайз, хөгжим</li>
               <li>Chill zone</li>
             </ul>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Most Popular</span>
+            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -393,7 +439,7 @@
                 <span class="pkg-visual-option__label">Тайзны эффект</span>
               </label>
             </div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -401,13 +447,27 @@
               <div class="pkg-price">280,000₮<span class="pkg-per">-с эхлэнэ</span></div>
             </div>
             <ul class="pkg-features">
-              <li>MC / Хөтлөгч</li>
-              <li>Хөтөлбөрийн зохион байгуулалт</li>
-              <li>Event coordination</li>
-              <li>Full production management</li>
+              <li>Experience бүх үйлчилгээ</li>
+              <li>Хөтөлбөрийн найруулагч</li>
+              <li>Эвент зохион байгуулагч</li>
+              <li>Хөтлөгч</li>
+              <li>Хамгаалтын алба</li>
+              <li>Эмнэлгийн тусламж</li>
             </ul>
-            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production">Үнийн санал авах</a>
+            <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
+            <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
+        </div>
+        <div class="camp-gallery" data-camp-gallery="mobile" aria-label="Нүүдлийн кемп зургийн цомог">
+          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__viewport">
+            <div class="camp-gallery__track"></div>
+            <div class="camp-gallery__empty" hidden>
+              <p>Зургийн цомог удахгүй нэмэгдэнэ.</p>
+              <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
+            </div>
+          </div>
+          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
     </div>
@@ -551,8 +611,12 @@
           <span class="quote-prefill__val" id="prefill-tier-val"></span>
         </div>
         <div class="quote-prefill__row" id="prefill-row-feature" hidden>
-          <span class="quote-prefill__key">Нэмэлт үйлчилгээ</span>
+          <span class="quote-prefill__key">Visual feature</span>
           <span class="quote-prefill__val" id="prefill-feature-val"></span>
+        </div>
+        <div class="quote-prefill__row" id="prefill-row-shuttle" hidden>
+          <span class="quote-prefill__key">Shuttle Service</span>
+          <span class="quote-prefill__val" id="prefill-shuttle-val"></span>
         </div>
         <input type="hidden" name="camp_name" id="field-camp-name">
         <input type="hidden" name="package_tier" id="field-package-tier">
@@ -576,8 +640,12 @@
           <input id="email" name="email" type="email" autocomplete="email">
         </div>
         <div class="quote-form__field">
-          <label for="event-date">Хүссэн огноо</label>
-          <input id="event-date" name="event_date" type="date" required>
+          <label for="start-datetime">Эхлэх огноо, цаг</label>
+          <input id="start-datetime" name="start_datetime" type="datetime-local" required>
+        </div>
+        <div class="quote-form__field">
+          <label for="end-datetime">Дуусах огноо, цаг</label>
+          <input id="end-datetime" name="end_datetime" type="datetime-local" required>
         </div>
         <div class="quote-form__field">
           <label for="guest-count">Хүний тоо</label>
@@ -585,7 +653,17 @@
         </div>
         <div class="quote-form__field quote-form__field--full">
           <label for="event-type">Арга хэмжээний төрөл</label>
-          <input id="event-type" name="event_type" type="text">
+          <select id="event-type" name="event_type">
+            <option value="">Сонгоно уу</option>
+            <option value="Байгууллагын аялал">Байгууллагын аялал</option>
+            <option value="Team building">Team building</option>
+            <option value="Retreat">Retreat</option>
+            <option value="Байгууллагын ой">Байгууллагын ой</option>
+            <option value="Сургалт / workshop">Сургалт / workshop</option>
+            <option value="VIP event">VIP event</option>
+            <option value="Festival / outdoor event">Festival / outdoor event</option>
+            <option value="Other">Other</option>
+          </select>
         </div>
         <div class="quote-form__field quote-form__field--full" id="location-field-wrap" hidden>
           <label for="location">Кемп байгуулах байршил <span class="quote-form__required" aria-hidden="true">*</span></label>
@@ -593,12 +671,21 @@
           <input id="location" name="location" type="text" placeholder="Жишээ: Архангай — Өгий нуур">
         </div>
         <div class="quote-form__field quote-form__field--full">
+          <label for="shuttle-service">Shuttle Service</label>
+          <select id="shuttle-service" name="shuttle_service">
+            <option value="Сонгохгүй">Сонгохгүй</option>
+            <option value="Өдрөөр / 2 талдаа — 1,000,000₮">Өдрөөр / 2 талдаа — 1,000,000₮</option>
+            <option value="Хоног / 2 талдаа — 1,200,000₮">Хоног / 2 талдаа — 1,200,000₮</option>
+          </select>
+          <small class="quote-form__helper-text">Shuttle Service нь зочдын тээвэрлэлтийн үйлчилгээ бөгөөд Нүүдлийн кемпийн логистикийн зардлаас тусдаа тооцогдоно.</small>
+        </div>
+        <div class="quote-form__field quote-form__field--full">
           <label for="extra-info">Нэмэлт мэдээлэл</label>
           <textarea id="extra-info" name="extra_info" rows="4"></textarea>
         </div>
       </div>
       <p class="quote-form__message" id="quote-form-message" aria-live="polite"></p>
-      <button class="btn btn--accent" type="submit">Илгээх</button>
+      <button class="btn btn--accent" type="submit">Урьдчилсан санал авах</button>
     </form>
   </div>
 </div>

--- a/main.js
+++ b/main.js
@@ -5,9 +5,9 @@
   // Future-ready config: add pricing when realtime estimation is ready
   var PACKAGE_CONFIG = {
     camps: {
-      'camp-c':      { name: 'C Кемп',         isMobile: false },
-      'camp-b':      { name: 'B Кемп',         isMobile: false },
       'camp-a':      { name: 'A Кемп',         isMobile: false },
+      'camp-b':      { name: 'B Кемп',         isMobile: false },
+      'camp-c':      { name: 'C Кемп',         isMobile: false },
       'camp-mobile': { name: 'Нүүдлийн кемп',  isMobile: true  }
     },
     tiers: {
@@ -18,7 +18,11 @@
     addons: {
       'LED Screen':     { price: null },
       'Moonbeam Lounge':{ price: null },
-      'Тайзны эффект':  { price: null }
+      'Тайзны эффект':  { price: null },
+      'Shuttle Service':{
+        price: 1000000,
+        description: '45 хүний автобус · УБ ↔ Кемп / 2 талдаа'
+      }
     }
   };
 
@@ -110,12 +114,68 @@
     });
   }
 
+  function initCampDetailGalleries(camps) {
+    if (!camps) return;
+
+    document.querySelectorAll('[data-camp-gallery]').forEach(function (gallery) {
+      var key = gallery.getAttribute('data-camp-gallery');
+      var images = (camps[key] || []).slice(0, 6);
+      var track = gallery.querySelector('.camp-gallery__track');
+      var emptyState = gallery.querySelector('.camp-gallery__empty');
+      var viewport = gallery.querySelector('.camp-gallery__viewport');
+      var prev = gallery.querySelector('.camp-gallery__arrow--prev');
+      var next = gallery.querySelector('.camp-gallery__arrow--next');
+      if (!track) {
+        return;
+      }
+
+      if (images.length === 0) {
+        if (track) track.style.display = 'none';
+        if (prev) prev.hidden = true;
+        if (next) next.hidden = true;
+        if (viewport) viewport.classList.add('is-empty');
+        if (emptyState) emptyState.hidden = false;
+        return;
+      }
+
+      if (track) track.style.display = '';
+      if (prev) prev.hidden = false;
+      if (next) next.hidden = false;
+      if (viewport) viewport.classList.remove('is-empty');
+      if (emptyState) emptyState.hidden = true;
+
+      track.innerHTML = '';
+      images.forEach(function (src) {
+        var img = document.createElement('img');
+        img.className = 'camp-gallery__img defer-img';
+        img.src = PLACEHOLDER;
+        img.setAttribute('data-src', src);
+        img.alt = 'Кемпийн зураг';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        track.appendChild(img);
+      });
+
+      var scrollByAmount = function () {
+        return Math.max(220, Math.floor(track.clientWidth * 0.5));
+      };
+
+      if (prev) prev.addEventListener('click', function () {
+        track.scrollBy({ left: -scrollByAmount(), behavior: 'smooth' });
+      });
+      if (next) next.addEventListener('click', function () {
+        track.scrollBy({ left: scrollByAmount(), behavior: 'smooth' });
+      });
+    });
+  }
+
   // ── INIT FROM MANIFEST ───────────────────────────────────────
   // Must run before deferred-img observer and carousel init
   var manifest = window.NOMAAD_IMAGES || {};
   initHeroSlider(manifest.hero);
   initGallery(manifest.gallery);
   initCampCarousels(manifest.camps);
+  initCampDetailGalleries(manifest.camps);
 
   // ── MOBILE NAV TOGGLE ────────────────────────────────────────
   var nav = document.querySelector('.nav');
@@ -282,17 +342,45 @@
   var campCards = document.querySelectorAll('[data-camp-target]');
   if (campCards.length > 0) {
     var campDetails = document.querySelectorAll('.camp-detail');
-    var showCampDetail = function (targetId) {
+    var resetCampState = function () {
       campCards.forEach(function (card) {
-        card.classList.toggle('is-active', card.dataset.campTarget === targetId);
+        card.classList.remove('is-active');
+        card.setAttribute('aria-expanded', 'false');
+        var cta = card.querySelector('[data-camp-cta]');
+        if (cta) cta.textContent = 'Багц үзэх →';
+      });
+      campDetails.forEach(function (detail) { detail.classList.remove('is-open'); });
+    };
+    var showCampDetail = function (targetId) {
+      var targetDetail = null;
+      campCards.forEach(function (card) {
+        var isTarget = card.dataset.campTarget === targetId;
+        card.classList.toggle('is-active', isTarget);
+        card.setAttribute('aria-expanded', isTarget ? 'true' : 'false');
+        var cta = card.querySelector('[data-camp-cta]');
+        if (cta) cta.textContent = isTarget ? 'Хаах ↑' : 'Багц үзэх →';
       });
       campDetails.forEach(function (detail) {
-        detail.classList.toggle('is-open', detail.id === targetId);
+        var isTarget = detail.id === targetId;
+        detail.classList.toggle('is-open', isTarget);
+        if (isTarget) targetDetail = detail;
       });
+      if (targetDetail) {
+        window.setTimeout(function () {
+          targetDetail.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }, 120);
+      }
     };
     campCards.forEach(function (card) {
-      card.addEventListener('click', function () { showCampDetail(card.dataset.campTarget); });
+      card.addEventListener('click', function () {
+        if (card.classList.contains('is-active')) {
+          resetCampState();
+          return;
+        }
+        showCampDetail(card.dataset.campTarget);
+      });
     });
+    resetCampState();
   }
 
   // ── CONTACT FORM (AJAX Netlify) ───────────────────────────────
@@ -341,39 +429,73 @@
     const prefillCampRow = document.getElementById('prefill-row-camp');
     const prefillTierRow = document.getElementById('prefill-row-tier');
     const prefillFeatRow = document.getElementById('prefill-row-feature');
+    const prefillShuttleRow = document.getElementById('prefill-row-shuttle');
     const prefillCampVal = document.getElementById('prefill-camp-val');
     const prefillTierVal = document.getElementById('prefill-tier-val');
     const prefillFeatVal = document.getElementById('prefill-feature-val');
+    const prefillShuttleVal = document.getElementById('prefill-shuttle-val');
     const fieldCampName  = document.getElementById('field-camp-name');
     const fieldTier      = document.getElementById('field-package-tier');
     const fieldFeature   = document.getElementById('field-visual-feature');
     const locationWrap   = document.getElementById('location-field-wrap');
     const locationInput  = document.getElementById('location');
+    const shuttleServiceSelect = document.getElementById('shuttle-service');
+
+    const applyLocationVisibility = (camp) => {
+      var normalizedCamp = (camp || '').trim();
+      var isMobile = normalizedCamp === 'Нүүдлийн кемп';
+      if (locationWrap) {
+        locationWrap.hidden = !isMobile;
+        locationWrap.style.display = isMobile ? '' : 'none';
+      }
+      if (locationInput) {
+        locationInput.required = isMobile;
+        if (!isMobile) locationInput.value = '';
+      }
+    };
+
+    const collectSelectedAddons = (groupName) => {
+      if (!groupName) return [];
+      return Array.from(document.querySelectorAll('input[name="' + groupName + '"]:checked'))
+        .map((input) => input.value)
+        .filter(Boolean);
+    };
 
     const openQuoteModal = (prefill) => {
       quoteModal.classList.add('is-open');
       quoteModal.setAttribute('aria-hidden', 'false');
       document.body.classList.add('modal-open');
+      var camp = (prefill && prefill.camp) || '';
 
       if (prefillBox) {
-        var camp    = (prefill && prefill.camp)    || '';
         var tier    = (prefill && prefill.tier)    || '';
         var feature = (prefill && prefill.feature) || '';
+        var addOns  = (prefill && prefill.addOns)  || [];
+        var shuttleService = (prefill && prefill.shuttleService) || 'Сонгохгүй';
 
         if (fieldCampName) fieldCampName.value = camp;
         if (fieldTier)     fieldTier.value     = tier;
         if (fieldFeature)  fieldFeature.value  = feature;
+        if (shuttleServiceSelect) shuttleServiceSelect.value = shuttleService;
 
-        var hasPrefill = !!(camp || tier || feature);
+        var hasPrefill = !!(camp || tier || feature || shuttleService !== 'Сонгохгүй');
         if (prefillBox)     prefillBox.hidden     = !hasPrefill;
         if (prefillCampRow) { prefillCampRow.hidden = !camp;    if (prefillCampVal) prefillCampVal.textContent = camp; }
         if (prefillTierRow) { prefillTierRow.hidden = !tier;    if (prefillTierVal) prefillTierVal.textContent = tier; }
         if (prefillFeatRow) { prefillFeatRow.hidden = !feature; if (prefillFeatVal) prefillFeatVal.textContent = feature; }
+        if (prefillShuttleRow) {
+          var showShuttle = shuttleService && shuttleService !== 'Сонгохгүй';
+          prefillShuttleRow.hidden = !showShuttle;
+          if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleService;
+        }
 
-        var isMobile = camp === 'Нүүдлийн кемп';
-        if (locationWrap)  locationWrap.hidden   = !isMobile;
-        if (locationInput) locationInput.required = isMobile;
+        if (addOns.indexOf('Shuttle Service') !== -1 && shuttleServiceSelect && shuttleServiceSelect.value === 'Сонгохгүй') {
+          shuttleServiceSelect.value = 'Өдрөөр / 2 талдаа — 1,000,000₮';
+          if (prefillShuttleRow) prefillShuttleRow.hidden = false;
+          if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleServiceSelect.value;
+        }
       }
+      applyLocationVisibility(camp);
 
       window.setTimeout(() => {
         if (firstInput) firstInput.focus();
@@ -388,8 +510,8 @@
       if (fieldCampName) fieldCampName.value = '';
       if (fieldTier)     fieldTier.value     = '';
       if (fieldFeature)  fieldFeature.value  = '';
-      if (locationWrap)  locationWrap.hidden   = true;
-      if (locationInput) locationInput.required = false;
+      if (shuttleServiceSelect) shuttleServiceSelect.value = 'Сонгохгүй';
+      applyLocationVisibility('');
     };
 
     quoteOpeners.forEach((link) => {
@@ -398,14 +520,29 @@
         var campName    = (link.dataset.campName    || '').trim();
         var tier        = (link.dataset.tier        || '').trim();
         var visualGroup = (link.dataset.visualGroup || '').trim();
+        var addonGroup  = (link.dataset.addonGroup  || '').trim();
         var feature     = '';
         if (visualGroup) {
           var checked = document.querySelector('input[name="' + visualGroup + '"]:checked');
           feature = checked ? checked.value : '';
+          if (!feature) {
+            window.alert('Experience багцын нэмэлт үйлчилгээний 1 сонголт хийнэ үү.');
+            return;
+          }
         }
-        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature } : null);
+        var addOns = collectSelectedAddons(addonGroup);
+        var shuttlePrefill = addOns.indexOf('Shuttle Service') !== -1 ? 'Өдрөөр / 2 талдаа — 1,000,000₮' : 'Сонгохгүй';
+        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature, addOns: addOns, shuttleService: shuttlePrefill } : null);
       });
     });
+
+    if (shuttleServiceSelect) {
+      shuttleServiceSelect.addEventListener('change', () => {
+        var shuttleValue = shuttleServiceSelect.value || 'Сонгохгүй';
+        if (prefillShuttleRow) prefillShuttleRow.hidden = shuttleValue === 'Сонгохгүй';
+        if (prefillShuttleVal) prefillShuttleVal.textContent = shuttleValue;
+      });
+    }
 
     closeTargets.forEach((el) => {
       el.addEventListener('click', () => closeQuoteModal());
@@ -445,18 +582,24 @@
       submitBtn.textContent = 'Илгээж байна…';
 
       const payload = {
+        camp:           (fd.get('camp_name')     || '').trim(),
+        tier:           (fd.get('package_tier')  || '').trim(),
+        visual_feature: (fd.get('visual_feature')|| '').trim(),
+        shuttle_service:(fd.get('shuttle_service') || '').trim(),
+        location:       ((fd.get('camp_name') || '').trim() === 'Нүүдлийн кемп') ? (fd.get('location') || '').trim() : '',
+        notes:          (fd.get('extra_info')    || '').trim(),
         company:        (fd.get('organization')  || '').trim(),
         contact_name:   (fd.get('contact_name')  || '').trim(),
         phone,
         email,
-        event_date:     (fd.get('event_date')    || '').trim(),
+        start_datetime: (fd.get('start_datetime')|| '').trim(),
+        end_datetime:   (fd.get('end_datetime')  || '').trim(),
+        event_date:     (fd.get('start_datetime')|| '').trim(),
         guest_count:    (fd.get('guest_count')   || '').trim(),
         event_type:     (fd.get('event_type')    || '').trim(),
-        location:       (fd.get('location')      || '').trim(),
         camp_name:      (fd.get('camp_name')     || '').trim(),
         package_tier:   (fd.get('package_tier')  || '').trim(),
-        visual_feature: (fd.get('visual_feature')|| '').trim(),
-        notes:          (fd.get('extra_info')    || '').trim(),
+        shuttle_service_label: (fd.get('shuttle_service') || '').trim(),
         source:         'nomaadcamp.com'
       };
 
@@ -476,7 +619,7 @@
         quoteMessage.className = 'quote-form__message quote-form__message--error';
       } finally {
         submitBtn.disabled = false;
-        submitBtn.textContent = 'Илгээх';
+        submitBtn.textContent = 'Урьдчилсан санал авах';
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -1352,6 +1352,7 @@ body.modal-open { overflow: hidden; }
   color: var(--charcoal);
 }
 .quote-form input,
+.quote-form select,
 .quote-form textarea {
   width: 100%;
   border: 1px solid rgba(31, 42, 35, 0.22);
@@ -1400,6 +1401,7 @@ body.modal-open { overflow: hidden; }
   .quote-modal { padding: 0.5rem; }
   .quote-modal__dialog { padding: 2.6rem 1rem 1.2rem; border-radius: 10px; }
   .quote-form input,
+  .quote-form select,
   .quote-form textarea { padding: 0.75rem 0.85rem; font-size: 1rem; }
   .hero--corporate {
     min-height: 78vh;
@@ -1420,6 +1422,8 @@ body.modal-open { overflow: hidden; }
 }
 .camp-card {
   position: relative;
+  display: flex;
+  flex-direction: column;
   appearance: none;
   border: 1px solid rgba(31, 42, 35, 0.15);
   background: #fff;
@@ -1429,8 +1433,8 @@ body.modal-open { overflow: hidden; }
   cursor: pointer;
   transition: border-color 0.2s var(--ease), transform 0.2s var(--ease), box-shadow 0.2s var(--ease);
   box-shadow: 0 8px 24px rgba(31, 42, 35, 0.08);
+  min-height: 100%;
 }
-.camp-card:hover { transform: translateY(-3px); }
 .camp-card img {
   width: 100%;
   height: 170px;
@@ -1448,35 +1452,79 @@ body.modal-open { overflow: hidden; }
   background: linear-gradient(180deg, rgba(10, 14, 12, 0.05) 0%, rgba(10, 14, 12, 0.28) 100%);
   pointer-events: none;
 }
+.camp-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 170px;
+  background: radial-gradient(120% 90% at 50% -10%, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0) 55%),
+              linear-gradient(135deg, rgba(47, 62, 47, 0.14), rgba(234, 227, 213, 0.04) 60%);
+  pointer-events: none;
+  z-index: 1;
+}
 .camp-card-body {
   position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   padding: 1.02rem 1rem 1.2rem;
+}
+.camp-card-body h3 {
+  font-size: 1.07rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 .camp-card-body p {
   font-size: 0.95rem;
   margin-top: 0.35rem;
 }
+.camp-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-top: auto;
+  padding-top: 0.85rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgba(31, 42, 35, 0.62);
+  transition: transform 0.22s var(--ease), color 0.22s var(--ease);
+}
 .camp-size {
-  color: var(--primary-forest);
-  font-weight: 700;
+  color: rgba(47, 62, 47, 0.9);
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+.camp-card-body p:last-of-type {
+  color: rgba(26, 26, 26, 0.68);
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 .camp-card.is-active {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px rgba(198, 93, 46, 0.3), 0 16px 30px rgba(31, 42, 35, 0.12);
+  transform: translateY(-2px) scale(1.012);
+  box-shadow: 0 0 0 1px rgba(198, 93, 46, 0.34), 0 22px 42px rgba(31, 42, 35, 0.2);
+}
+.camp-card.is-active .camp-card-cta {
+  color: var(--accent);
 }
 .camp-card:hover {
-  transform: translateY(-3px) scale(1.01);
-  box-shadow: 0 16px 34px rgba(31, 42, 35, 0.14);
+  transform: translateY(-4px) scale(1.012);
+  box-shadow: 0 20px 40px rgba(31, 42, 35, 0.18);
+}
+.camp-card:hover .camp-card-cta {
+  transform: translateX(5px);
+  color: var(--charcoal);
 }
 .camp-card:hover img {
-  transform: scale(1.04);
-  filter: saturate(0.98) contrast(1.04) brightness(0.96);
+  transform: scale(1.06);
+  filter: saturate(1) contrast(1.05) brightness(0.97);
 }
 .camp-detail-wrap {
   margin-top: 1.1rem;
 }
 .camp-detail {
-  display: none;
   grid-template-columns: 1fr 1.25fr;
   gap: 1rem;
   background: var(--card-bg);
@@ -1484,9 +1532,6 @@ body.modal-open { overflow: hidden; }
   border-radius: 14px;
   padding: 1rem;
   box-shadow: var(--card-shadow);
-}
-.camp-detail.is-open {
-  display: grid;
 }
 .camp-detail-text p {
   margin: 0.7rem 0 1rem;
@@ -1537,6 +1582,17 @@ body.modal-open { overflow: hidden; }
     grid-template-columns: 1fr;
   }
   .camp-card-body { padding: 0.9rem 0.95rem 1.05rem; }
+  .camp-gallery {
+    grid-template-columns: 1fr;
+  }
+  .camp-gallery__arrow {
+    display: none;
+  }
+  .camp-gallery__img {
+    width: 70vw;
+    max-width: 220px;
+    height: 118px;
+  }
 }
 
 @media (max-width: 560px) {
@@ -1641,9 +1697,28 @@ body.modal-open { overflow: hidden; }
 
 /* ── PACKAGE PRICING ── */
 .camp-detail.has-packages.is-open {
+  max-height: 2200px;
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  padding: 1rem;
+  border-color: var(--card-line);
+  box-shadow: var(--card-shadow);
+}
+.camp-detail.has-packages {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transform: translateY(-8px);
+  padding-top: 0;
+  padding-bottom: 0;
+  border-color: transparent;
+  box-shadow: none;
+  transition: max-height 0.45s var(--ease), opacity 0.3s ease, transform 0.35s var(--ease), padding 0.35s var(--ease), border-color 0.25s ease, box-shadow 0.25s ease;
 }
 .camp-detail.has-packages .camp-detail-text p {
   margin-bottom: 0;
@@ -1653,6 +1728,73 @@ body.modal-open { overflow: hidden; }
   grid-template-columns: repeat(3, 1fr);
   gap: 0.85rem;
   padding-top: 0.75rem;
+}
+.camp-gallery {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+.camp-gallery__viewport {
+  overflow: hidden;
+  border-radius: 12px;
+}
+.camp-gallery__viewport.is-empty {
+  border: 1px solid rgba(31, 42, 35, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.8), rgba(245, 241, 232, 0.8));
+}
+.camp-gallery__track {
+  display: flex;
+  gap: 0.55rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 0.15rem;
+}
+.camp-gallery__track::-webkit-scrollbar {
+  display: none;
+}
+.camp-gallery__img {
+  width: clamp(170px, 22vw, 250px);
+  height: 128px;
+  border-radius: 10px;
+  object-fit: cover;
+  flex: 0 0 auto;
+  border: 1px solid rgba(31, 42, 35, 0.12);
+  scroll-snap-align: start;
+}
+.camp-gallery__arrow {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 42, 35, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--charcoal);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.2s var(--ease), border-color 0.2s var(--ease), transform 0.2s var(--ease);
+}
+.camp-gallery__arrow:hover {
+  background: #fff;
+  border-color: rgba(198, 93, 46, 0.45);
+  transform: translateY(-1px);
+}
+.camp-gallery__empty {
+  padding: 0.95rem 1rem;
+  color: rgba(26, 26, 26, 0.72);
+}
+.camp-gallery__empty p {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.camp-gallery__empty small {
+  display: block;
+  margin-top: 0.28rem;
+  font-size: 0.76rem;
+  color: rgba(26, 26, 26, 0.56);
 }
 .pkg-card {
   position: relative;
@@ -1915,6 +2057,12 @@ body.modal-open { overflow: hidden; }
   font-weight: 400;
 }
 
+.pkg-note {
+  margin-top: 0.45rem;
+  font-size: 0.76rem;
+  color: rgba(26, 26, 26, 0.6);
+  line-height: 1.45;
+}
 /* ── MOBILE CAMP NOTE ─────────────────────────────────────── */
 .camp-mobile-note {
   font-size: 0.82rem;


### PR DESCRIPTION
### Motivation

- Improve the camps browsing and booking experience by adding shuttle service as an optional add-on and clearer package CTAs. 
- Provide per-camp image galleries and smoother camp-detail interactions for better visual context. 
- Make the quote form more structured and actionable by using start/end datetimes and a typed `event_type` select. 

### Description

- Updated HTML for the camps grid including reordering/default selection, added inline `camp-card-cta` toggles, added `data-addon-group` attributes to package CTA links, and localized package badge text. 
- Extended package content and pricing labels (unified Production card copy and added starting price display) and added `pkg-note` information; added shuttle-related markup and per-camp gallery containers. 
- Revised quote modal markup to replace `event_date` with `start_datetime` and `end_datetime`, replaced free-text `event_type` with a `select`, added a `shuttle_service` select, updated prefills (`prefill-row-shuttle`) and changed submit button text to `Урьдчилсан санал авах`. 
- JavaScript: updated `PACKAGE_CONFIG` to include a `Shuttle Service` addon with price and description, added `initCampDetailGalleries()` to populate camp galleries from the manifest, improved camp detail toggling (open/close, aria-expanded, reset state and `scrollIntoView`), added `collectSelectedAddons()` and shuttle prefill logic, and changed the quote payload to include `start_datetime`, `end_datetime`, and `shuttle_service` fields. 
- CSS: added styles for `select` in the quote form, refreshed camp card visuals and hover/active states, implemented gallery layout and controls, transitioned camp detail expand/collapse, and added `pkg-note` styling. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbc047784832182a7f12b86e594cf)