### PR TITLE
fix: regenerate manifest to include 01.webp in mobile-camp gallery

### DIFF
--- a/images/manifest.js
+++ b/images/manifest.js
@@ -42,6 +42,7 @@ window.NOMAAD_IMAGES = {
     "mobile": {
       "cover": "/images/camps/mobile-camp/cover/mobile-cover.webp",
       "gallery": [
+        "/images/camps/mobile-camp/gallery/01.webp",
         "/images/camps/mobile-camp/gallery/mobile-01.webp",
         "/images/camps/mobile-camp/gallery/mobile-02.webp"
       ]


### PR DESCRIPTION
Fixes #80

The manifest.js was stale and missing 01.webp which was recently added to images/camps/mobile-camp/gallery/. The generator script already accepts any filename — the manifest just needed to be regenerated.

Generated with [Claude Code](https://claude.ai/code)