### PR TITLE
fix: add missing mobile-camp gallery image to manifest

### DIFF
--- a/images/manifest.js
+++ b/images/manifest.js
@@ -43,6 +43,7 @@ window.NOMAAD_IMAGES = {
       "cover": "/images/camps/mobile-camp/cover/mobile-cover.webp",
       "gallery": [
         "/images/camps/mobile-camp/gallery/01.webp",
+        "/images/camps/mobile-camp/gallery/481080444_1152247173363351_5856001241748562614_n.jpg",
         "/images/camps/mobile-camp/gallery/mobile-01.webp",
         "/images/camps/mobile-camp/gallery/mobile-02.webp"
       ]


### PR DESCRIPTION
Add missing image `481080444_1152247173363351_5856001241748562614_n.jpg` to the mobile-camp gallery in `images/manifest.js`.

The generator script already accepts any filename — the manifest just needed to be regenerated after the image was added to disk.

Closes #82

Generated with [Claude Code](https://claude.ai/code)