### PR TITLE
fix: add cache-busting to manifest script tag

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -1,12 +1,13 @@
 // scripts/generate-manifest.js
 // Auto-generates images/manifest.js by scanning image folders.
 // Run: node scripts/generate-manifest.js
-// Netlify runs this automatically as the build command.
+// Netlify and GitHub Actions run this automatically as the build command.
 
 'use strict';
 
-const fs   = require('fs');
-const path = require('path');
+const fs     = require('fs');
+const path   = require('path');
+const crypto = require('crypto');
 
 const ROOT      = path.join(__dirname, '..');
 const CAMPS_DIR = path.join(ROOT, 'images', 'camps');
@@ -62,6 +63,23 @@ const out = [
 ].join('\n');
 
 fs.writeFileSync(OUTPUT, out, 'utf8');
+
+// Cache-bust the manifest <script> tag in index.html so browsers always
+// fetch the new file when its content changes (GitHub Pages serves with
+// Cache-Control: max-age=600, so without this browsers show stale images).
+const hash      = crypto.createHash('sha256').update(out).digest('hex').slice(0, 8);
+const indexPath = path.join(ROOT, 'index.html');
+if (fs.existsSync(indexPath)) {
+  const html    = fs.readFileSync(indexPath, 'utf8');
+  const updated = html.replace(
+    /<script src="\/images\/manifest\.js(?:\?[^"]*)?"><\/script>/,
+    `<script src="/images/manifest.js?v=${hash}"></script>`
+  );
+  if (updated !== html) {
+    fs.writeFileSync(indexPath, updated, 'utf8');
+    console.log('index.html updated — manifest cache-bust hash: ' + hash);
+  }
+}
 
 console.log('manifest written → ' + path.relative(process.cwd(), OUTPUT));
 Object.entries(camps).forEach(([k, v]) =>


### PR DESCRIPTION
Fixes the browser caching issue that prevented newly added images from appearing after GitHub Pages deploy.

After `npm run build` regenerates `images/manifest.js`, the script now also updates the `<script src>` in `index.html` with a content-hash query string (?v=<8-char sha256>). GitHub Pages serves files with `Cache-Control: max-age=600`, so without this browsers serve the old manifest after deploy.

Closes #84

Generated with [Claude Code](https://claude.ai/code)