### PR TITLE
fix: add 3 missing gallery images to manifest and fix stale hardcoded paths

### DIFF
--- a/images/manifest.js
+++ b/images/manifest.js
@@ -20,6 +20,8 @@ window.NOMAAD_IMAGES = {
     "a": {
       "cover": "/images/camps/a-camp/cover/A-01.jpg",
       "gallery": [
+        "/images/camps/a-camp/gallery/481024639_1152238890030846_6226793545414696685_n.jpg",
+        "/images/camps/a-camp/gallery/481976416_1155736906347711_1687494666032244796_n.jpg",
         "/images/camps/a-camp/gallery/A-01.jpg",
         "/images/camps/a-camp/gallery/A-02.jpg",
         "/images/camps/a-camp/gallery/A-03.jpg"
@@ -28,6 +30,7 @@ window.NOMAAD_IMAGES = {
     "b": {
       "cover": "/images/camps/b-camp/cover/gallery-06.jpg",
       "gallery": [
+        "/images/camps/b-camp/gallery/DJI_20250725152831_0014_D.jpg",
         "/images/camps/b-camp/gallery/gallery-06.jpg",
         "/images/camps/b-camp/gallery/gallery-07.jpg",
         "/images/camps/b-camp/gallery/gallery-08.jpg"

--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
 <meta property="og:title" content="NOMAAD Camp — Байгууллагын арга хэмжээний бүрэн зохион байгуулалт">
 <meta property="og:description" content="Байгууллагын арга хэмжээ, багийн идэвхжүүлэлт, удирдлагын уулзалт, том хэмжээний эвентийг төлөвлөлтөөс гүйцэтгэл хүртэл нэгдсэн байдлаар хэрэгжүүлнэ.">
 <meta property="og:url" content="https://nomaadcamp.mn/">
-<meta property="og:image" content="https://nomaadcamp.mn/images/camps/a-camp/gallery-01.jpg">
+<meta property="og:image" content="https://nomaadcamp.mn/images/camps/a-camp/cover/A-01.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="preload" href="style.css" as="style">
 <link rel="stylesheet" href="style.css">
-<link rel="preload" as="image" href="/images/hero/gallery-04.jpg" fetchpriority="high">
+<link rel="preload" as="image" href="/images/hero/gallery-05.jpg" fetchpriority="high">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Inter+Tight:wght@600;700&family=Manrope:wght@500;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
Fixes #86

## Changes

- `images/manifest.js`: Added 3 gallery images that were physically present in the repo but missing from the manifest (a-camp: 2 images, b-camp: 1 image)
- `index.html`: Fixed og:image URL pointing to old flat path; fixed hero preload pointing to nonexistent file

Generated with [Claude Code](https://claude.ai/code)