### PR TITLE
Refine camp galleries into premium featured-image experience

### DIFF
--- a/images/manifest.js
+++ b/images/manifest.js
@@ -39,6 +39,7 @@ window.NOMAAD_IMAGES = {
     "c": {
       "cover": "/images/camps/c-camp/cover/c-cover.jpg",
       "gallery": [
+        "/images/camps/c-camp/gallery/2.webp",
         "/images/camps/c-camp/gallery/c-01.jpg"
       ]
     },

--- a/index.html
+++ b/index.html
@@ -211,10 +211,11 @@
             <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
             <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production" data-addon-group="addon_shuttle_c">Үнийн санал авах</a>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
         <div class="camp-gallery" data-camp-gallery="c" aria-label="C Кемп зургийн цомог">
-          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__featured">
+            <img class="camp-gallery__featured-img defer-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="Кемпийн онцлох зураг" loading="lazy" decoding="async">
+          </div>
           <div class="camp-gallery__viewport">
             <div class="camp-gallery__track"></div>
             <div class="camp-gallery__empty" hidden>
@@ -222,7 +223,6 @@
               <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
             </div>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -296,7 +296,9 @@
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="b" aria-label="B Кемп зургийн цомог">
-          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__featured">
+            <img class="camp-gallery__featured-img defer-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="Кемпийн онцлох зураг" loading="lazy" decoding="async">
+          </div>
           <div class="camp-gallery__viewport">
             <div class="camp-gallery__track"></div>
             <div class="camp-gallery__empty" hidden>
@@ -304,7 +306,6 @@
               <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
             </div>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -376,10 +377,11 @@
             <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
             <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production" data-addon-group="addon_shuttle_a">Үнийн санал авах</a>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
         <div class="camp-gallery" data-camp-gallery="a" aria-label="A Кемп зургийн цомог">
-          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__featured">
+            <img class="camp-gallery__featured-img defer-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="Кемпийн онцлох зураг" loading="lazy" decoding="async">
+          </div>
           <div class="camp-gallery__viewport">
             <div class="camp-gallery__track"></div>
             <div class="camp-gallery__empty" hidden>
@@ -387,7 +389,6 @@
               <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
             </div>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
 
@@ -459,10 +460,11 @@
             <p class="pkg-note">Уран бүтээлч, артист болон тусгай production элементүүдийг тусгайлан тооцоолно.</p>
             <a class="btn pkg-cta pkg-cta--forest" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production" data-addon-group="addon_shuttle_mobile">Үнийн санал авах</a>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
         <div class="camp-gallery" data-camp-gallery="mobile" aria-label="Нүүдлийн кемп зургийн цомог">
-          <button class="camp-gallery__arrow camp-gallery__arrow--prev" type="button" aria-label="Өмнөх зураг">‹</button>
+          <div class="camp-gallery__featured">
+            <img class="camp-gallery__featured-img defer-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="Кемпийн онцлох зураг" loading="lazy" decoding="async">
+          </div>
           <div class="camp-gallery__viewport">
             <div class="camp-gallery__track"></div>
             <div class="camp-gallery__empty" hidden>
@@ -470,7 +472,6 @@
               <small>Тухайн кемпийн бодит зураг, орчны мэдээллийг энд байршуулна.</small>
             </div>
           </div>
-          <button class="camp-gallery__arrow camp-gallery__arrow--next" type="button" aria-label="Дараагийн зураг">›</button>
         </div>
       </article>
     </div>
@@ -694,7 +695,7 @@
   </div>
 </div>
 
-<script src="/images/manifest.js"></script>
+<script src="/images/manifest.js?v=a4817ed3"></script>
 <script src="/main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -136,27 +136,31 @@
       var track = gallery.querySelector('.camp-gallery__track');
       var emptyState = gallery.querySelector('.camp-gallery__empty');
       var viewport = gallery.querySelector('.camp-gallery__viewport');
-      var prev = gallery.querySelector('.camp-gallery__arrow--prev');
-      var next = gallery.querySelector('.camp-gallery__arrow--next');
+      var featured = gallery.querySelector('.camp-gallery__featured');
+      var featuredImg = gallery.querySelector('.camp-gallery__featured-img');
       if (!track) return;
 
-      if (images.length === 0) {
-        track.style.display = 'none';
-        if (prev) prev.hidden = true;
-        if (next) next.hidden = true;
-        if (viewport) viewport.classList.add('is-empty');
-        if (emptyState) emptyState.hidden = false;
-        return;
-      }
+      var setEmptyState = function (isEmpty) {
+        track.style.display = isEmpty ? 'none' : '';
+        if (featured) featured.hidden = isEmpty;
+        if (viewport) viewport.classList.toggle('is-empty', isEmpty);
+        if (emptyState) emptyState.hidden = !isEmpty;
+      };
 
-      track.style.display = '';
-      if (prev) prev.hidden = false;
-      if (next) next.hidden = false;
-      if (viewport) viewport.classList.remove('is-empty');
-      if (emptyState) emptyState.hidden = true;
+      var setFeaturedImage = function (thumb) {
+        if (!featuredImg || !thumb) return;
+        featuredImg.src = thumb.getAttribute('data-src') || thumb.src;
+        featuredImg.setAttribute('data-src', thumb.getAttribute('data-src') || thumb.src);
+        featuredImg.alt = thumb.alt || 'Кемпийн онцлох зураг';
+
+        track.querySelectorAll('.camp-gallery__img').forEach(function (item) {
+          item.classList.toggle('is-active', item === thumb);
+        });
+      };
 
       track.innerHTML = '';
-      images.forEach(function (src) {
+
+      images.forEach(function (src, index) {
         var img = document.createElement('img');
         img.className = 'camp-gallery__img defer-img';
         img.src = PLACEHOLDER;
@@ -164,29 +168,40 @@
         img.alt = 'Кемпийн зураг';
         img.loading = 'lazy';
         img.decoding = 'async';
+        img.tabIndex = 0;
+        img.setAttribute('role', 'button');
+        img.setAttribute('aria-label', 'Зураг сонгох');
+        img.addEventListener('click', function () {
+          setFeaturedImage(img);
+        });
+        img.addEventListener('keydown', function (event) {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setFeaturedImage(img);
+          }
+        });
         img.addEventListener('error', function () {
           img.remove();
           if (track.children.length === 0) {
-            track.style.display = 'none';
-            if (prev) prev.hidden = true;
-            if (next) next.hidden = true;
-            if (viewport) viewport.classList.add('is-empty');
-            if (emptyState) emptyState.hidden = false;
+            setEmptyState(true);
           }
         }, { once: true });
         track.appendChild(img);
+
+        if (index === 0 && featuredImg) {
+          featuredImg.src = PLACEHOLDER;
+          featuredImg.setAttribute('data-src', src);
+          featuredImg.alt = 'Кемпийн онцлох зураг';
+        }
       });
 
-      var scrollByAmount = function () {
-        return Math.max(220, Math.floor(track.clientWidth * 0.5));
-      };
+      if (track.children.length === 0) {
+        setEmptyState(true);
+        return;
+      }
 
-      if (prev) prev.addEventListener('click', function () {
-        track.scrollBy({ left: -scrollByAmount(), behavior: 'smooth' });
-      });
-      if (next) next.addEventListener('click', function () {
-        track.scrollBy({ left: scrollByAmount(), behavior: 'smooth' });
-      });
+      setEmptyState(false);
+      setFeaturedImage(track.querySelector('.camp-gallery__img'));
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -1582,16 +1582,13 @@ body.modal-open { overflow: hidden; }
     grid-template-columns: 1fr;
   }
   .camp-card-body { padding: 0.9rem 0.95rem 1.05rem; }
-  .camp-gallery {
-    grid-template-columns: 1fr;
-  }
-  .camp-gallery__arrow {
-    display: none;
+  .camp-gallery__featured {
+    border-radius: 10px;
   }
   .camp-gallery__img {
-    width: 70vw;
-    max-width: 220px;
-    height: 118px;
+    width: 42vw;
+    max-width: 170px;
+    height: 96px;
   }
 }
 
@@ -1731,9 +1728,21 @@ body.modal-open { overflow: hidden; }
 }
 .camp-gallery {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 0.5rem;
+  gap: 0.7rem;
+}
+.camp-gallery__featured {
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 42, 35, 0.14);
+  background: rgba(248, 245, 238, 0.75);
+  box-shadow: 0 6px 18px rgba(31, 42, 35, 0.08);
+}
+.camp-gallery__featured-img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  display: block;
+  object-fit: cover;
+  transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
 }
 .camp-gallery__viewport {
   overflow: hidden;
@@ -1749,37 +1758,33 @@ body.modal-open { overflow: hidden; }
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  scroll-snap-type: x mandatory;
-  padding-bottom: 0.15rem;
+  padding: 0.15rem 0.1rem 0.35rem;
 }
 .camp-gallery__track::-webkit-scrollbar {
   display: none;
 }
 .camp-gallery__img {
-  width: clamp(170px, 22vw, 250px);
-  height: 128px;
+  width: clamp(110px, 14vw, 160px);
+  height: 86px;
   border-radius: 10px;
   object-fit: cover;
   flex: 0 0 auto;
-  border: 1px solid rgba(31, 42, 35, 0.12);
-  scroll-snap-align: start;
-}
-.camp-gallery__arrow {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  border: 1px solid rgba(31, 42, 35, 0.2);
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--charcoal);
-  font-size: 1.2rem;
-  line-height: 1;
+  border: 1px solid rgba(31, 42, 35, 0.18);
   cursor: pointer;
-  transition: background 0.2s var(--ease), border-color 0.2s var(--ease), transform 0.2s var(--ease);
+  opacity: 0.74;
+  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease), border-color 0.25s var(--ease);
 }
-.camp-gallery__arrow:hover {
-  background: #fff;
-  border-color: rgba(198, 93, 46, 0.45);
+.camp-gallery__img:hover,
+.camp-gallery__img:focus-visible {
+  opacity: 0.95;
+  border-color: rgba(198, 93, 46, 0.5);
   transform: translateY(-1px);
+  outline: none;
+}
+.camp-gallery__img.is-active {
+  opacity: 1;
+  border-color: rgba(198, 93, 46, 0.68);
+  box-shadow: 0 0 0 1px rgba(198, 93, 46, 0.24);
 }
 .camp-gallery__empty {
   padding: 0.95rem 1rem;


### PR DESCRIPTION
### Motivation
- Replace the compact thumbnail carousel with a more cinematic, editorial gallery that highlights one large featured image above a thumbnail strip while preserving the existing manifest-driven image loading and section structure. 
- Remove side arrow navigation and shift interaction to direct thumbnail selection to achieve a minimal, hospitality-grade UX. 
- Keep transitions subtle, preserve responsive mobile behavior, and avoid autoplay or flashy animation. 

### Description
- HTML: removed side arrow buttons in each `data-camp-gallery` block and injected a `div.camp-gallery__featured` containing an `img.camp-gallery__featured-img` to host the large featured image while leaving the existing `.camp-gallery__track` in place. 
- JS: replaced the previous scroll-by-arrow behavior in `initCampDetailGalleries` so the code now populates the thumbnail track from `manifest.camps[key].gallery`, sets up click and keyboard (`Enter`/`Space`) handlers on thumbnails, updates the featured image, and toggles an `is-active` class on the selected thumbnail, while preserving placeholder/deferred `data-src` loading and empty-state handling. 
- CSS: added styles for the framed featured panel and `camp-gallery__featured-img`, refined thumbnail sizing, hover/focus/active states, subtle transitions, and responsive adjustments for mobile; arrow-related styles were removed/cleaned up. 
- Build/manifest: ran the existing build step which regenerated `images/manifest.js` (cache-busted script URL) using the same manifest pipeline so no manifest or package logic was reworked. 

### Testing
- Ran `npm run build` which completed successfully and regenerated `images/manifest.js`. 
- Verified markup and behavior changes by searching the codebase with `rg -n "camp-gallery__arrow" index.html style.css main.js` and inspected updated `index.html`, `main.js`, and `style.css` to confirm arrows removed and featured-layout added. 
- No automated visual regression tooling was available in this environment, so only the build and static checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed6c3c72108321aedad223a5b5085a)