### PR TITLE
refine #why-nomaad section with updated content, capability grid, stats, and visual strip

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,17 +484,59 @@
   <div class="container">
     <div class="section-head reveal">
       <span class="eyebrow">Яагаад NOMAAD</span>
-      <h2>Байгууллагын хэрэгцээнд төвлөрсөн зохион байгуулалт</h2>
+      <h2>Нэг баг. Нэг систем. Нэг хариуцлага.</h2>
+      <p>Байгууллагын outdoor арга хэмжээнд шаардлагатай бүх зүйлийг нэг баг нэг системтэй удирдана. Тохижилт, техник тоног төхөөрөмж, хоол, зохион байгуулалт хүртэл бүгд нэг дор.</p>
+      <p class="wn-positioning">Бид майхан түрээслэдэггүй. Байгууллагын outdoor арга хэмжээг системтэй удирддаг.</p>
     </div>
-    <div class="pillars reveal">
-      <div class="pillar">Хаалттай, зөвхөн танай байгууллагад зориулсан орчин</div>
-      <div class="pillar">Байршил сонгох уян хатан боломж</div>
-      <div class="pillar">Тайз, гэрэлтүүлэг, техник нэг дор</div>
-      <div class="pillar">Хоол, амралтын бүс бүхий зохион байгуулалт</div>
-      <div class="pillar">Бэлтгэл, явцыг нэгдсэн байдлаар удирдана</div>
-      <div class="pillar">Хүсэлт бүр холбогдох ажилтанд шууд хүрдэг</div>
-      <div class="pillar">Зураг, мэдээллээр явцыг хянах боломж</div>
-      <div class="pillar">Туршлагатай, нэгдсэн баг</div>
+    <div class="wn-cap-grid reveal">
+      <div class="wn-cap-item">
+        <span class="wn-cap-num">01</span>
+        <h3>Хаалттай орчин</h3>
+        <p>Зөвхөн танай байгууллагад зориулсан зохион байгуулалт. Гадны зочин байхгүй.</p>
+      </div>
+      <div class="wn-cap-item">
+        <span class="wn-cap-num">02</span>
+        <h3>Нэгдсэн дэд бүтэц</h3>
+        <p>Тайз, хөгжим, гэрэлтүүлэг, асар, катеринг үйлчилгээг нэг баг хариуцна. Та тусдаа гүйцэтгэгч хайх шаардлагагүй.</p>
+      </div>
+      <div class="wn-cap-item">
+        <span class="wn-cap-num">03</span>
+        <h3>Суурин болон нүүдлийн</h3>
+        <p>Манай суурин кемп дээр эсвэл таны сонгосон газарт зохион байгуулна. Байршил саад болохгүй.</p>
+      </div>
+      <div class="wn-cap-item">
+        <span class="wn-cap-num">04</span>
+        <h3>Нэгдсэн удирдлага</h3>
+        <p>Бэлтгэлийн явц, гүйцэтгэл, арга хэмжээний дараах тайланг нэгдсэн байдлаар хүргэнэ. Таны цагийг хэмнэнэ.</p>
+      </div>
+    </div>
+    <div class="wn-stats reveal">
+      <div class="wn-stat">
+        <span class="wn-stat-num">130+</span>
+        <span class="wn-stat-label">байгууллага итгэсэн</span>
+      </div>
+      <div class="wn-stat">
+        <span class="wn-stat-num">1000</span>
+        <span class="wn-stat-label">хүн хүртэл нэг арга хэмжээнд</span>
+      </div>
+      <div class="wn-stat">
+        <span class="wn-stat-num">8+</span>
+        <span class="wn-stat-label">жилийн корпорейт outdoor туршлага</span>
+      </div>
+    </div>
+    <div class="wn-strip reveal">
+      <figure class="wn-strip-img">
+        <img src="/images/camps/a-camp/cover/A-01.jpg" alt="Тайзны бэлтгэл" loading="lazy" decoding="async">
+        <figcaption>Тайзны бэлтгэл</figcaption>
+      </figure>
+      <figure class="wn-strip-img">
+        <img src="/images/gallery/gallery-09.jpg" alt="Хоол үйлчилгээ" loading="lazy" decoding="async">
+        <figcaption>Хоол үйлчилгээ</figcaption>
+      </figure>
+      <figure class="wn-strip-img">
+        <img src="/images/gallery/gallery-20.jpg" alt="Lounge бүс" loading="lazy" decoding="async">
+        <figcaption>Lounge бүс</figcaption>
+      </figure>
     </div>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -2438,3 +2438,158 @@ body.home-page .footer {
     padding: 0.9rem 0.9rem 0.9rem 1.1rem;
   }
 }
+
+/* ─ Why NOMAAD refinement — all selectors scoped to #why-nomaad ─ */
+
+#why-nomaad .wn-positioning {
+  border-left: 2px solid var(--sand);
+  background: var(--sand-dim);
+  padding: 0.7rem 1rem 0.7rem 1.2rem;
+  border-radius: 0 6px 6px 0;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  max-width: 600px;
+  margin-top: 1.25rem;
+  color: var(--muted);
+}
+
+#why-nomaad .wn-cap-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+#why-nomaad .wn-cap-item {
+  border: 1px solid var(--line-2);
+  border-left: 2px solid var(--sand);
+  border-radius: 10px;
+  padding: 1.4rem 1.4rem 1.4rem 1.5rem;
+  background: rgba(255, 255, 255, 0.03);
+  transition: background 0.2s var(--ease);
+}
+
+#why-nomaad .wn-cap-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+#why-nomaad .wn-cap-num {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--sand);
+  margin-bottom: 0.6rem;
+}
+
+#why-nomaad .wn-cap-item h3 {
+  font-size: 1.02rem;
+  font-weight: 600;
+  line-height: 1.35;
+  margin-bottom: 0.45rem;
+}
+
+#why-nomaad .wn-cap-item p {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+#why-nomaad .wn-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--line-2);
+  border-bottom: 1px solid var(--line-2);
+  padding: 1.75rem 0;
+  margin-bottom: 2.5rem;
+}
+
+#why-nomaad .wn-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 1.5rem;
+  gap: 0.35rem;
+}
+
+#why-nomaad .wn-stat + .wn-stat {
+  border-left: 1px solid var(--line-2);
+}
+
+#why-nomaad .wn-stat-num {
+  font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+  font-weight: 600;
+  color: var(--sand);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+#why-nomaad .wn-stat-label {
+  font-size: 0.84rem;
+  color: var(--muted);
+  line-height: 1.45;
+  max-width: 140px;
+}
+
+#why-nomaad .wn-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+#why-nomaad .wn-strip-img {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  aspect-ratio: 4 / 3;
+  margin: 0;
+}
+
+#why-nomaad .wn-strip-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: saturate(0.7) brightness(0.88);
+  transition: filter 0.3s var(--ease);
+}
+
+#why-nomaad .wn-strip-img:hover img {
+  filter: saturate(0.85) brightness(0.95);
+}
+
+#why-nomaad .wn-strip-img figcaption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text);
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.4));
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 768px) {
+  #why-nomaad .wn-cap-grid {
+    grid-template-columns: 1fr;
+  }
+  #why-nomaad .wn-stats {
+    grid-template-columns: 1fr;
+    padding: 1.25rem 0;
+  }
+  #why-nomaad .wn-stat {
+    padding: 0.75rem 1.25rem;
+    align-items: flex-start;
+    text-align: left;
+    border-left: none;
+  }
+  #why-nomaad .wn-stat + .wn-stat {
+    border-left: none;
+    border-top: 1px solid var(--line-2);
+  }
+  #why-nomaad .wn-strip {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Improves the #why-nomaad section on nomaadcamp.com as a controlled refinement (not a redesign).

Changes:
- New heading: "Нэг баг. Нэг систем. Нэг хариуцлага."
- Supporting paragraph + subtle positioning line with sand accent border
- 2×2 capability grid replacing the 8-pillar checklist
- 3-column stat row (130+ | 1000 | 8+ years)
- Visual strip with 3 local images
- All CSS scoped to #why-nomaad, existing CSS variables only

Closes #92

Generated with [Claude Code](https://claude.ai/code)