### PR TITLE
Refine Why NOMAAD capability card visual hierarchy

### DIFF
--- a/style.css
+++ b/style.css
@@ -2461,38 +2461,50 @@ body.home-page .footer {
 }
 
 #why-nomaad .wn-cap-item {
-  border: 1px solid var(--line-2);
-  border-left: 2px solid var(--sand);
+  border: 1px solid rgba(245, 245, 240, 0.1);
+  border-left: 1px solid rgba(200, 168, 120, 0.36);
+  border-bottom-color: rgba(245, 245, 240, 0.13);
   border-radius: 10px;
-  padding: 1.4rem 1.4rem 1.4rem 1.5rem;
-  background: rgba(255, 255, 255, 0.03);
-  transition: background 0.2s var(--ease);
+  padding: 1.45rem 1.45rem 1.45rem 1.5rem;
+  background: rgba(255, 255, 255, 0.022);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), inset 0 -1px 0 rgba(0, 0, 0, 0.18);
+  transition: background 0.42s var(--ease), border-color 0.42s var(--ease), box-shadow 0.42s var(--ease);
 }
 
 #why-nomaad .wn-cap-item:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(245, 245, 240, 0.14);
+  border-bottom-color: rgba(200, 168, 120, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), inset 0 -1px 0 rgba(200, 168, 120, 0.14);
 }
 
 #why-nomaad .wn-cap-num {
   display: inline-block;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  color: var(--sand);
-  margin-bottom: 0.6rem;
+  letter-spacing: 0.12em;
+  color: rgba(200, 168, 120, 0.72);
+  margin-bottom: 0.68rem;
+  line-height: 1;
 }
 
 #why-nomaad .wn-cap-item h3 {
   font-size: 1.02rem;
   font-weight: 600;
   line-height: 1.35;
-  margin-bottom: 0.45rem;
+  margin-bottom: 0.52rem;
+  transition: color 0.42s var(--ease);
+}
+
+#why-nomaad .wn-cap-item:hover h3 {
+  color: #f5f4ef;
 }
 
 #why-nomaad .wn-cap-item p {
   font-size: 0.9rem;
-  line-height: 1.6;
-  color: var(--muted);
+  line-height: 1.72;
+  color: rgba(154, 156, 148, 0.92);
+  max-width: 34ch;
 }
 
 #why-nomaad .wn-stats {


### PR DESCRIPTION
### Motivation
- Subtly elevate the visual hierarchy of the capability cards in `#why-nomaad` so they read as a calm, premium, editorial system rather than boxed feature tiles.
- Preserve the existing layout, typography and palette while reducing border dominance, adding restrained surface depth, and improving readability and hover refinement.

### Description
- Softened card borders by lowering contrast and making the left-edge accent less heavy via updated `border` and `border-left` values in `#why-nomaad .wn-cap-item` in `style.css`.
- Added a minimal inset surface treatment using very subtle `box-shadow: inset(...)` and reduced base background opacity to create slight depth without visible cast shadows or gradients.
- Improved hover state to use slower transitions (0.42s ease), a subtle background lift, gentler border-color/bottom-edge accent, and a title brighten effect via a hover rule for `h3` in `.wn-cap-item`.
- Tuned number labels with slightly smaller size, increased letter-spacing and lowered opacity for a more architectural tone, and refined copy readability by increasing `line-height` and limiting text measure with `max-width: 34ch` for `.wn-cap-item p`.

### Testing
- Ran `npm run build` and the build completed successfully (a non-blocking npm env warning was emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc5c5ba988321b87b23592ef0c0e3)