### PR TITLE
Remove package-level shuttle options; require location only for "Нүүдлийн кемп" with smooth reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,27 +152,6 @@
               <li>Үндсэн гэрэлтүүлэг</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_ess" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_ess" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_ess" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -181,7 +160,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential" data-addon-group="shuttle_c_ess">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
@@ -219,27 +198,6 @@
             </div>
             <p class="pkg-note">Өглөөний 07:30–09:00 цагт уулын оройд байрлах coffee &amp; tea corner ажиллана. Тайван хөгжмийн орчинтой.</p>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_exp" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_exp" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_exp" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -248,7 +206,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c" data-addon-group="shuttle_c_exp">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -275,27 +233,6 @@
               <li>Нэмэлт асар, майхан</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_pro" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_pro" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_c_pro" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -304,7 +241,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production" data-addon-group="shuttle_c_pro">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="c" aria-label="C Кемп зургийн цомог">
@@ -341,27 +278,6 @@
               <li>Үндсэн гэрэлтүүлэг</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_ess" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_ess" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_ess" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -370,7 +286,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential" data-addon-group="shuttle_b_ess">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
@@ -408,27 +324,6 @@
             </div>
             <p class="pkg-note">Өглөөний 07:30–09:00 цагт уулын оройд байрлах coffee &amp; tea corner ажиллана. Тайван хөгжмийн орчинтой.</p>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_exp" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_exp" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_exp" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -437,7 +332,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b" data-addon-group="shuttle_b_exp">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -464,27 +359,6 @@
               <li>Нэмэлт асар, майхан</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_pro" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_pro" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_b_pro" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -493,7 +367,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production" data-addon-group="shuttle_b_pro">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="b" aria-label="B Кемп зургийн цомог">
@@ -530,27 +404,6 @@
               <li>Үндсэн гэрэлтүүлэг</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_ess" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_ess" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_ess" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -559,7 +412,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential" data-addon-group="shuttle_a_ess">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
@@ -597,27 +450,6 @@
             </div>
             <p class="pkg-note">Өглөөний 07:30–09:00 цагт уулын оройд байрлах coffee &amp; tea corner ажиллана. Тайван хөгжмийн орчинтой.</p>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_exp" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_exp" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_exp" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -626,7 +458,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a" data-addon-group="shuttle_a_exp">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -653,27 +485,6 @@
               <li>Нэмэлт асар, майхан</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_pro" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_pro" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_a_pro" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -682,7 +493,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production" data-addon-group="shuttle_a_pro">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="a" aria-label="A Кемп зургийн цомог">
@@ -719,27 +530,6 @@
               <li>Үндсэн гэрэлтүүлэг</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_ess" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_ess" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_ess" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -748,7 +538,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential" data-addon-group="shuttle_mob_ess">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
@@ -786,27 +576,6 @@
             </div>
             <p class="pkg-note">Өглөөний 07:30–09:00 цагт уулын оройд байрлах coffee &amp; tea corner ажиллана. Тайван хөгжмийн орчинтой.</p>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_exp" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_exp" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_exp" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -815,7 +584,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile" data-addon-group="shuttle_mob_exp">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -842,27 +611,6 @@
               <li>Нэмэлт асар, майхан</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Нэмэлт сонголт</p>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Тээврийн үйлчилгээ <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <div class="pkg-visual-selector" style="margin-top:0.3rem">
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_pro" value="Сонгохгүй" checked>
-                    <span class="pkg-visual-option__label">Сонгохгүй</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_pro" value="Өдрөөр / 2 талдаа — 1,000,000₮">
-                    <span class="pkg-visual-option__label">Өдрөөр — 1,000,000₮</span>
-                  </label>
-                  <label class="pkg-visual-option">
-                    <input type="radio" name="shuttle_mob_pro" value="Хоног / 2 талдаа — 1,200,000₮">
-                    <span class="pkg-visual-option__label">Хоногоор — 1,200,000₮</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
               <div class="pkg-accordion__body">
@@ -871,7 +619,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production" data-addon-group="shuttle_mob_pro">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="mobile" aria-label="Нүүдлийн кемп зургийн цомог">
@@ -1145,20 +893,20 @@
           <span class="quote-field-error" id="err-guests" role="alert" hidden></span>
         </div>
         <div class="quote-estimate quote-form__field--full" id="quote-estimate" hidden></div>
-        <div class="quote-form__field quote-form__field--full" id="location-field-wrap" hidden>
+        <div class="quote-form__field quote-form__field--full quote-form__field--conditional" id="location-field-wrap" aria-hidden="true">
           <label for="location">Кемп байгуулах байршил <span class="quote-form__required" aria-hidden="true">*</span></label>
           <small class="quote-form__helper-text">Аймаг, сум эсвэл Google Maps location оруулна уу</small>
           <input id="location" name="location" type="text" placeholder="Жишээ: Архангай — Өгий нуур">
           <span class="quote-field-error" id="err-location" role="alert" hidden></span>
         </div>
         <div class="quote-form__field quote-form__field--full">
-          <label for="shuttle-service">Shuttle Service</label>
+          <label for="shuttle-service">Тээврийн үйлчилгээ</label>
           <select id="shuttle-service" name="shuttle_service">
             <option value="Сонгохгүй">Сонгохгүй</option>
             <option value="Өдрөөр / 2 талдаа — 1,000,000₮">Өдрөөр / 2 талдаа — 1,000,000₮</option>
             <option value="Хоног / 2 талдаа — 1,200,000₮">Хоног / 2 талдаа — 1,200,000₮</option>
           </select>
-          <small class="quote-form__helper-text">Shuttle Service нь зочдын тээвэрлэлтийн үйлчилгээ бөгөөд Нүүдлийн кемпийн логистикийн зардлаас тусдаа тооцогдоно.</small>
+          <small class="quote-form__helper-text">Тээврийн үйлчилгээ нь зочдын зорчих хөдөлгөөнийг зохион байгуулах нэмэлт сонголт бөгөөд Нүүдлийн кемпийн логистикийн зардлаас тусдаа тооцогдоно.</small>
         </div>
         <div class="quote-form__field quote-form__field--full">
           <label for="extra-info">Нэмэлт мэдээлэл</label>

--- a/main.js
+++ b/main.js
@@ -682,7 +682,10 @@
 
     function applyLocationVisibility(camp) {
       var isMobile = (camp || '').trim() === 'Нүүдлийн кемп';
-      if (locationWrap) locationWrap.hidden = !isMobile;
+      if (locationWrap) {
+        locationWrap.classList.toggle('is-visible', isMobile);
+        locationWrap.setAttribute('aria-hidden', String(!isMobile));
+      }
       if (locationInput) {
         locationInput.required = isMobile;
         if (!isMobile) locationInput.value = '';
@@ -836,18 +839,12 @@
         var campName    = (link.dataset.campName    || '').trim();
         var tier        = (link.dataset.tier        || '').trim();
         var visualGroup = (link.dataset.visualGroup || '').trim();
-        var addonGroup  = (link.dataset.addonGroup  || '').trim();
         var feature     = '';
         if (visualGroup) {
           var checked = document.querySelector('input[name="' + visualGroup + '"]:checked');
           feature = checked ? checked.value : '';
         }
-        var shuttle = 'Сонгохгүй';
-        if (addonGroup) {
-          var addonChecked = document.querySelector('input[name="' + addonGroup + '"]:checked');
-          shuttle = addonChecked ? addonChecked.value : 'Сонгохгүй';
-        }
-        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature, shuttle: shuttle } : null);
+        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature, shuttle: 'Сонгохгүй' } : null);
       });
     });
 

--- a/style.css
+++ b/style.css
@@ -1345,6 +1345,22 @@ body.modal-open { overflow: hidden; }
   flex-direction: column;
   gap: 0.35rem;
 }
+.quote-form__field--conditional {
+  overflow: hidden;
+  opacity: 0;
+  max-height: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition: opacity 220ms ease, max-height 260ms ease, transform 220ms ease, margin 220ms ease;
+  margin-top: 0;
+}
+.quote-form__field--conditional.is-visible {
+  opacity: 1;
+  max-height: 220px;
+  transform: translateY(0);
+  pointer-events: auto;
+  margin-top: 0.1rem;
+}
 .quote-form__field--full { grid-column: 1 / -1; }
 .quote-form label {
   font-size: 0.86rem;


### PR DESCRIPTION
### Motivation
- Remove duplicated "Тээврийн үйлчилгээ" controls from package cards so transport is configured only in the quote/inquiry form and package UI becomes cleaner and more premium.
- Ensure the "Кемп байгуулах байршил" location field appears only when customers select the mobile camp ("Нүүдлийн кемп") because A/B/C camps have fixed locations.
- Improve UX by revealing/hiding the location field with a smooth animation rather than a sudden layout jump while preserving current responsive layout and Mongolian copy.

### Description
- Removed all shuttle option accordions and radio inputs from package cards in `index.html` and removed package CTA `data-addon-group` attributes so package cards no longer surface transport options.
- Kept a single transport selector inside the quote modal and changed its label/helper text to Mongolian (`Тээврийн үйлчилгээ`) and clarified helper copy in `index.html`.
- Changed location field wrapper in `index.html` to use a conditional class (`quote-form__field--conditional`) and `aria-hidden` for accessibility instead of toggling the `hidden` attribute.
- Updated `main.js` to centralize prefill behavior: removed package-level addon-group handling, always prefill shuttle as `'Сонгохгүй'` for CTA-driven opens, and replaced `locationWrap.hidden = ...` with a class toggle + `aria-hidden` and required toggling so the `location` field is required only for `Нүүдлийн кемп`.
- Added CSS transitions in `style.css` for `.quote-form__field--conditional` / `.is-visible` to implement a smooth fade/slide reveal without breaking mobile responsiveness.

### Testing
- Ran `node --check main.js` to validate JS syntax — succeeded.
- Searched the markup to confirm shuttle option blocks and `data-addon-group` wiring were removed using `rg`/grep patterns — succeeded.
- Verified presence of `applyLocationVisibility` hook, `quote-form__field--conditional` class, `location-field-wrap`, and `shuttle-service` in the modified files using `rg` — succeeded.
- Attempted a headless screenshot with `chromium --headless` to visually validate the form, but the environment lacked `chromium` so the screenshot step failed (non-blocking visual test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ced59cf083218ecced89b81bb0a1)