### PR TITLE
fix: mobile-responsive CSS for day-program modal title

### DIFF
--- a/style.css
+++ b/style.css
@@ -1334,6 +1334,8 @@ body.modal-open { overflow: hidden; }
 .quote-modal__dialog h2 {
   color: var(--charcoal);
   margin-bottom: 0.85rem;
+  overflow-wrap: break-word;
+  line-height: 1.3;
 }
 .quote-form__grid {
   display: grid;
@@ -1416,6 +1418,7 @@ body.modal-open { overflow: hidden; }
   .quote-form__grid { grid-template-columns: 1fr; }
   .quote-modal { padding: 0.5rem; }
   .quote-modal__dialog { padding: 2.6rem 1rem 1.2rem; border-radius: 10px; }
+  .quote-modal__dialog h2 { font-size: clamp(1.05rem, 4.5vw, 1.35rem); line-height: 1.35; }
   .quote-form input,
   .quote-form select,
   .quote-form textarea { padding: 0.75rem 0.85rem; font-size: 1rem; }


### PR DESCRIPTION
Adds `overflow-wrap` and mobile font-size rule to `.quote-modal__dialog h2` so the longer day-program title wraps gracefully on narrow screens.

The JS dynamic logic for the quote modal (isDayProgram detection, title update, field visibility, required toggles, close reset) was already implemented in PR #135.

Closes #136

Generated with [Claude Code](https://claude.ai/code)