### PR TITLE
Hide camp/tier dropdowns in quote modal for day program CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,7 +765,7 @@
         <div class="pkg-divider" aria-hidden="true"></div>
         <p class="pkg-note">Тохиромжтой арга хэмжээ: HR сургалт, удирдлагын уулзалт, стратегийн төлөвлөлт, борлуулалтын багийн уулзалт, дотоод workshop</p>
         <div class="pkg-divider" aria-hidden="true"></div>
-        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Хагас өдрийн хөтөлбөр" data-tier="Half Day">Өдрийн хөтөлбөрийн санал авах</a>
+        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Half Day хөтөлбөр" data-tier="Half Day">Өдрийн хөтөлбөрийн санал авах</a>
       </div>
 
       <div class="pkg-card pkg-card--featured" role="listitem">
@@ -788,7 +788,7 @@
         <div class="pkg-divider" aria-hidden="true"></div>
         <p class="pkg-note">Тохиромжтой арга хэмжээ: executive offsite, жилийн төлөвлөлтийн өдөр, sales kickoff, year-end leadership day, founder retreat</p>
         <div class="pkg-divider" aria-hidden="true"></div>
-        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Бүтэн өдрийн хөтөлбөр" data-tier="Full Day">Өдрийн хөтөлбөрийн санал авах</a>
+        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Full Day хөтөлбөр" data-tier="Full Day">Өдрийн хөтөлбөрийн санал авах</a>
       </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -756,8 +756,10 @@
       if (isDayProgram) {
         filterSelectOptions(campSelect, DAY_PROGRAM_OPTIONS);
         filterSelectOptions(tierSelect, DAY_PROGRAM_TIERS);
-        if (campSelect) campSelect.value = camp;
-        if (tierSelect) tierSelect.value = tier;
+        if (campSelect) { campSelect.value = camp; campSelect.required = false; }
+        if (tierSelect) { tierSelect.value = tier; tierSelect.required = false; }
+        if (campFieldWrap) campFieldWrap.style.display = 'none';
+        if (tierFieldWrap) tierFieldWrap.style.display = 'none';
         if (contextHint) {
           contextHint.textContent = 'Та Өдрийн хөтөлбөр · ' + getDayProgramLabel(camp) + ' багцын үнийн санал авах гэж байна.';
           contextHint.hidden = false;
@@ -765,8 +767,10 @@
       } else if (isCamp) {
         filterSelectOptions(campSelect, CAMP_OPTIONS);
         filterSelectOptions(tierSelect, CAMP_TIERS);
-        if (campSelect) campSelect.value = camp;
-        if (tierSelect) tierSelect.value = tier;
+        if (campSelect) { campSelect.value = camp; campSelect.required = true; }
+        if (tierSelect) { tierSelect.value = tier; tierSelect.required = true; }
+        if (campFieldWrap) campFieldWrap.style.display = '';
+        if (tierFieldWrap) tierFieldWrap.style.display = '';
         if (contextHint) {
           contextHint.textContent = 'Та ' + camp + ' · ' + tier + ' багцын үнийн санал авах гэж байна.';
           contextHint.hidden = false;
@@ -774,8 +778,10 @@
       } else {
         resetSelectOptions(campSelect);
         resetSelectOptions(tierSelect);
-        if (campSelect) campSelect.value = camp;
-        if (tierSelect) tierSelect.value = tier;
+        if (campSelect) { campSelect.value = camp; campSelect.required = true; }
+        if (tierSelect) { tierSelect.value = tier; tierSelect.required = true; }
+        if (campFieldWrap) campFieldWrap.style.display = '';
+        if (tierFieldWrap) tierFieldWrap.style.display = '';
         if (contextHint) contextHint.hidden = true;
       }
 
@@ -804,6 +810,8 @@
       resetSelectOptions(tierSelect);
       if (campSelect) { campSelect.value = ''; campSelect.required = true; }
       if (tierSelect) { tierSelect.value = ''; tierSelect.required = true; }
+      if (campFieldWrap) campFieldWrap.style.display = '';
+      if (tierFieldWrap) tierFieldWrap.style.display = '';
       if (modalTitleEl) modalTitleEl.textContent = 'Үнийн санал авах';
       applyLocationVisibility('');
       clearAllErrors();


### PR DESCRIPTION
## өдрийн хөтөлбөрийн CTA-аас нээгдсэн modal-д Кемп ба Түвшин dropdown-ыг нуух

Closes #140

### Өөрчлөлтийн дэлгэрэнгүүд

- `index.html`: midweek CTA-н `data-camp-name` attribute-г `DAY_PROGRAM_OPTIONS` болон select option value-тай тохируулав
- `main.js`: `openQuoteModal` дотор isDayProgram үед campFieldWrap/tierFieldWrap-г display:none-р нуудаг, required attribute-г идэвхгүй болгодог
- `main.js`: `closeQuoteModal` дотор field-үүдийн visibility болон required-г сэргээдэг

Generated with [Claude Code](https://claude.ai/code)