### PR TITLE
feat: Quote modal UX simplification — remove generic CTAs & convert selects to hidden inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <a href="#contact">Холбоо барих</a>
   </div>
   <div class="nav-actions">
-    <a class="nav-cta" href="#quote-modal" data-quote-open="true">Үнийн санал авах</a>
+    <a class="nav-cta" href="tel:+97699179417">9917-9417</a>
     <button class="nav-toggle" type="button" aria-label="Цэс" aria-controls="primary-nav" aria-expanded="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
         <path d="M4 6h16M4 12h16M4 18h16"/>
@@ -69,8 +69,8 @@
     <h1>Зөвхөн танай байгууллагад зориулсан<br>кемпийн бүрэн шийдэл</h1>
     <p class="hero-sub">30-аас 1000 хүний арга хэмжээг бэлтгэлээс гүйцэтгэл хүртэл нэгдсэн байдлаар зохион байгуулна. Хаалттай, зөвхөн танай байгууллагад зориулсан орчин.</p>
     <div class="hero-actions">
-      <a class="btn btn--accent btn--lg" href="#quote-modal" data-quote-open="true">Үнийн санал авах</a>
-      <a class="btn btn--ghost-light btn--lg" href="#camps">Кемпүүд үзэх</a>
+      <a class="btn btn--accent btn--lg" href="#camps">Кемпүүд үзэх</a>
+      <a class="btn btn--ghost-light btn--lg" href="#midweek">Өдрийн хөтөлбөр үзэх</a>
     </div>
 
     <div class="hero-meta">
@@ -860,15 +860,18 @@
 <section class="section cta-final" id="contact">
   <div class="container reveal">
     <h2>Танай байгууллагад тохирсон арга хэмжээг хамтдаа зохион байгуулъя</h2>
-    <p>Хүний тоо, огноо, зорилгын мэдээллээ илгээнэ үү. Манай баг 24 цагийн дотор үнийн санал боловсруулж холбогдоно.</p>
-    <a class="btn btn--accent btn--lg" href="#quote-modal" data-quote-open="true">Үнийн санал авах</a>
+    <p>Кемп эсвэл өдрийн хөтөлбөрөөс сонгоод тохирох багцын үнийн санал авна уу.</p>
+    <div class="cta-final__actions">
+      <a class="btn btn--accent btn--lg" href="#camps">Кемпүүд үзэх</a>
+      <a class="btn btn--ghost-light btn--lg" href="#midweek">Өдрийн хөтөлбөр үзэх</a>
+    </div>
   </div>
 </section>
 </main>
 
 <div class="bottom-cta">
   <a class="phone" href="tel:+97699179417">9917-9417</a>
-  <a class="btn btn--accent" href="#quote-modal" data-quote-open="true">Үнийн санал авах</a>
+  <a class="btn btn--ghost" href="#camps">Кемпүүд үзэх</a>
 </div>
 
 <footer class="footer">
@@ -899,7 +902,7 @@
       <div class="footer-cta">
         <h3 class="footer-title">Холбоо барих</h3>
         <a href="tel:+97699179417" class="phone">9917-9417</a>
-        <a class="btn btn--accent" href="#quote-modal" data-quote-open="true">Үнийн санал авах</a>
+        <a href="mailto:info@nomaadcamp.mn">info@nomaadcamp.mn</a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -921,31 +921,8 @@
     <p class="quote-context-hint" id="quote-context-hint" hidden></p>
     <form class="quote-form" id="quote-form" novalidate>
       <div class="quote-form__grid">
-        <div class="quote-form__field" id="camp-field-wrap">
-          <label for="field-camp">Кемп <span class="quote-form__required" aria-hidden="true">*</span></label>
-          <select id="field-camp" name="camp_name" required>
-            <option value="">Сонгоно уу</option>
-            <option value="A Кемп">A Кемп</option>
-            <option value="B Кемп">B Кемп</option>
-            <option value="C Кемп">C Кемп</option>
-            <option value="Нүүдлийн кемп">Нүүдлийн кемп</option>
-            <option value="Half Day хөтөлбөр">Half Day хөтөлбөр</option>
-            <option value="Full Day хөтөлбөр">Full Day хөтөлбөр</option>
-          </select>
-          <span class="quote-field-error" id="err-camp" role="alert" hidden></span>
-        </div>
-        <div class="quote-form__field" id="tier-field-wrap">
-          <label for="field-tier">Түвшин <span class="quote-form__required" aria-hidden="true">*</span></label>
-          <select id="field-tier" name="package_tier" required>
-            <option value="">Сонгоно уу</option>
-            <option value="Essential">Essential</option>
-            <option value="Experience">Experience</option>
-            <option value="Production">Production</option>
-            <option value="Half Day">Half Day</option>
-            <option value="Full Day">Full Day</option>
-          </select>
-          <span class="quote-field-error" id="err-tier" role="alert" hidden></span>
-        </div>
+        <input type="hidden" id="field-camp" name="camp_name">
+        <input type="hidden" id="field-tier" name="package_tier">
         <div class="quote-form__field">
           <label for="org-name">Байгууллагын нэр <span class="quote-form__required" aria-hidden="true">*</span></label>
           <input id="org-name" name="organization" type="text" autocomplete="organization" required>

--- a/main.js
+++ b/main.js
@@ -637,12 +637,8 @@
     var shuttleSelect  = document.getElementById('shuttle-service');
     var contextHint    = document.getElementById('quote-context-hint');
     var estimateEl     = document.getElementById('quote-estimate');
-    var campFieldWrap  = document.getElementById('camp-field-wrap');
-    var tierFieldWrap  = document.getElementById('tier-field-wrap');
     var modalTitleEl   = document.getElementById('quote-modal-title');
 
-    var errCamp     = document.getElementById('err-camp');
-    var errTier     = document.getElementById('err-tier');
     var errOrg      = document.getElementById('err-org');
     var errContact  = document.getElementById('err-contact');
     var errPhone    = document.getElementById('err-phone');
@@ -667,8 +663,6 @@
     }
 
     function clearAllErrors() {
-      clearFieldError(errCamp,     campSelect);
-      clearFieldError(errTier,     tierSelect);
       clearFieldError(errOrg,      orgInput);
       clearFieldError(errContact,  contactInput);
       clearFieldError(errPhone,    phoneInput);
@@ -679,28 +673,7 @@
       clearFieldError(errLocation, locationInput);
     }
 
-    var CAMP_OPTIONS       = ['A Кемп', 'B Кемп', 'C Кемп', 'Нүүдлийн кемп'];
     var DAY_PROGRAM_OPTIONS = ['Half Day хөтөлбөр', 'Full Day хөтөлбөр'];
-    var CAMP_TIERS         = ['Essential', 'Experience', 'Production'];
-    var DAY_PROGRAM_TIERS  = ['Half Day', 'Full Day'];
-
-    function filterSelectOptions(selectEl, allowedValues) {
-      if (!selectEl) return;
-      Array.from(selectEl.options).forEach(function (opt) {
-        if (opt.value === '') return;
-        var allowed = allowedValues.indexOf(opt.value) !== -1;
-        opt.hidden   = !allowed;
-        opt.disabled = !allowed;
-      });
-    }
-
-    function resetSelectOptions(selectEl) {
-      if (!selectEl) return;
-      Array.from(selectEl.options).forEach(function (opt) {
-        opt.hidden   = false;
-        opt.disabled = false;
-      });
-    }
 
     function getDayProgramLabel(campName) {
       return campName === 'Half Day хөтөлбөр' ? 'Хагас өдрийн' : 'Бүтэн өдрийн';
@@ -743,7 +716,6 @@
       var shuttle = (prefill && prefill.shuttle) || 'Сонгохгүй';
 
       var isDayProgram = DAY_PROGRAM_OPTIONS.indexOf(camp) !== -1;
-      var isCamp       = CAMP_OPTIONS.indexOf(camp) !== -1;
 
       if (modalTitleEl) {
         if (isDayProgram) {
@@ -753,36 +725,19 @@
         }
       }
 
-      if (isDayProgram) {
-        filterSelectOptions(campSelect, DAY_PROGRAM_OPTIONS);
-        filterSelectOptions(tierSelect, DAY_PROGRAM_TIERS);
-        if (campSelect) { campSelect.value = camp; campSelect.required = false; }
-        if (tierSelect) { tierSelect.value = tier; tierSelect.required = false; }
-        if (campFieldWrap) campFieldWrap.style.display = 'none';
-        if (tierFieldWrap) tierFieldWrap.style.display = 'none';
-        if (contextHint) {
+      if (campSelect) campSelect.value = camp;
+      if (tierSelect) tierSelect.value = tier;
+
+      if (contextHint) {
+        if (isDayProgram) {
           contextHint.textContent = 'Та Өдрийн хөтөлбөр · ' + getDayProgramLabel(camp) + ' багцын үнийн санал авах гэж байна.';
           contextHint.hidden = false;
-        }
-      } else if (isCamp) {
-        filterSelectOptions(campSelect, CAMP_OPTIONS);
-        filterSelectOptions(tierSelect, CAMP_TIERS);
-        if (campSelect) { campSelect.value = camp; campSelect.required = true; }
-        if (tierSelect) { tierSelect.value = tier; tierSelect.required = true; }
-        if (campFieldWrap) campFieldWrap.style.display = '';
-        if (tierFieldWrap) tierFieldWrap.style.display = '';
-        if (contextHint) {
+        } else if (camp && tier) {
           contextHint.textContent = 'Та ' + camp + ' · ' + tier + ' багцын үнийн санал авах гэж байна.';
           contextHint.hidden = false;
+        } else {
+          contextHint.hidden = true;
         }
-      } else {
-        resetSelectOptions(campSelect);
-        resetSelectOptions(tierSelect);
-        if (campSelect) { campSelect.value = camp; campSelect.required = true; }
-        if (tierSelect) { tierSelect.value = tier; tierSelect.required = true; }
-        if (campFieldWrap) campFieldWrap.style.display = '';
-        if (tierFieldWrap) tierFieldWrap.style.display = '';
-        if (contextHint) contextHint.hidden = true;
       }
 
       if (visualSelect)  visualSelect.value  = feature;
@@ -794,9 +749,7 @@
       updateEstimate();
 
       window.setTimeout(function () {
-        var firstFocus = (camp && tier) ? orgInput : campSelect;
-        if (!firstFocus) firstFocus = orgInput;
-        if (firstFocus) firstFocus.focus();
+        if (orgInput) orgInput.focus();
       }, 20);
     }
 
@@ -806,37 +759,15 @@
       document.body.classList.remove('modal-open');
       if (contextHint) contextHint.hidden = true;
       if (estimateEl) estimateEl.hidden = true;
-      resetSelectOptions(campSelect);
-      resetSelectOptions(tierSelect);
-      if (campSelect) { campSelect.value = ''; campSelect.required = true; }
-      if (tierSelect) { tierSelect.value = ''; tierSelect.required = true; }
-      if (campFieldWrap) campFieldWrap.style.display = '';
-      if (tierFieldWrap) tierFieldWrap.style.display = '';
+      if (campSelect) campSelect.value = '';
+      if (tierSelect) tierSelect.value = '';
       if (modalTitleEl) modalTitleEl.textContent = 'Үнийн санал авах';
       applyLocationVisibility('');
       clearAllErrors();
     }
 
-    // Filter tier options and show/hide location field when camp select changes
-    if (campSelect) {
-      campSelect.addEventListener('change', function () {
-        var value = campSelect.value;
-        if (DAY_PROGRAM_OPTIONS.indexOf(value) !== -1) {
-          filterSelectOptions(tierSelect, DAY_PROGRAM_TIERS);
-        } else if (CAMP_OPTIONS.indexOf(value) !== -1) {
-          filterSelectOptions(tierSelect, CAMP_TIERS);
-        } else {
-          resetSelectOptions(tierSelect);
-        }
-        if (tierSelect) tierSelect.value = '';
-        applyLocationVisibility(value);
-        clearFieldError(errCamp, campSelect);
-      });
-    }
-
     // Clear inline errors on user input
     var clearOnChange = [
-      [tierSelect,    errTier,     tierSelect],
       [orgInput,      errOrg,      orgInput],
       [contactInput,  errContact,  contactInput],
       [phoneInput,    errPhone,    phoneInput],
@@ -916,8 +847,6 @@
       estimateEl.innerHTML = html;
     }
 
-    if (campSelect)    campSelect.addEventListener('change',  updateEstimate);
-    if (tierSelect)    tierSelect.addEventListener('change',  updateEstimate);
     if (guestInput)    guestInput.addEventListener('input',   updateEstimate);
     if (shuttleSelect) shuttleSelect.addEventListener('change', updateEstimate);
 
@@ -980,8 +909,6 @@
         if (!firstErrorEl) firstErrorEl = inputEl;
       }
 
-      if (!camp)    markError(errCamp,    campSelect,    'Кемп сонгоно уу.');
-      if (!tier)    markError(errTier,    tierSelect,    'Түвшин сонгоно уу.');
       if (!org)     markError(errOrg,     orgInput,      'Байгууллагын нэр оруулна уу.');
       if (!contact) markError(errContact, contactInput,  'Холбоо барих хүний нэр оруулна уу.');
 

--- a/style.css
+++ b/style.css
@@ -1277,6 +1277,19 @@ body.home-page .footer .footer-tagline::before {
 body.home-page .cta-final h2,
 body.home-page .cta-final p { color: rgba(255, 255, 255, 0.96); }
 .cta-final p { max-width: 720px; margin: 0.8rem auto 1.6rem; }
+.cta-final__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .cta-final__actions { flex-direction: column; align-items: stretch; }
+  .cta-final__actions .btn { width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+}
 
 body.modal-open { overflow: hidden; }
 .quote-modal {


### PR DESCRIPTION
Closes #142

## Summary

- Top nav: "Үнийн санал авах" товчийг `tel:+97699179417` утасны дугаар болгосон
- Hero: quote CTA арилгаж, "Кемпүүд үзэх" ба "Өдрийн хөтөлбөр үзэх" scroll CTA нэмэх
- Bottom-cta: quote товчийг ghost "Кемпүүд үзэх" болгосон
- Footer: quote CTA арилж, `info@nomaadcamp.mn` имэйл нэмэх
- cta-final: нэг quote товчийг хоёр хэсӯг навигац товчнууд болгосон
- Quote modal: camp & tier select элементүүдийг hidden input болгосон
- main.js: display/required toggle logic арилж, openQuoteModal/closeQuoteModal спрост болгосон

Generated with [Claude Code](https://claude.ai/code)