### PR TITLE
feat: add-on selector UI with real-time pricing in quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,7 +958,144 @@
           <input id="guest-count" name="guest_count" type="number" min="1" step="1" required>
           <span class="quote-field-error" id="err-guests" role="alert" hidden></span>
         </div>
-        <div class="quote-estimate quote-form__field--full" id="quote-estimate" hidden></div>
+
+        <!-- ── НЭМЭЛТ ҮЙЛЧИЛГЭЭ ─────────────────────────────────── -->
+        <div class="quote-form__field quote-form__field--full quote-addons-wrap" id="quote-addons-section">
+          <h3 class="quote-addons__title">Нэмэлт үйлчилгээ (заавал биш)</h3>
+          <p class="quote-addons__subtitle">Хэрэгцээтэй сонгож, үндсэн багц дээр нэмж захиалаарай</p>
+
+          <div class="quote-addons__group">
+            <h4 class="quote-addons__group-title">Хүний тоогоор тооцох нэмэлтүүд</h4>
+            <div class="quote-addons__grid quote-addons__grid--per-person">
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="welcome_drink" data-price="5000" data-type="per-person" data-label="Welcome drink">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Welcome drink</span>
+                  <span class="quote-addon-card__detail">4 төрөл сонголттой</span>
+                  <span class="quote-addon-card__price">+5,000₮ / хүн</span>
+                </div>
+                <div class="quote-addon-card__sub-options" hidden>
+                  <span class="quote-addon-card__sub-label">Ундааны төрөл:</span>
+                  <div class="quote-addon-card__radio-group">
+                    <label class="quote-addon-card__radio"><input type="radio" name="welcome_drink_type" value="lemon_water"> Lemon water</label>
+                    <label class="quote-addon-card__radio"><input type="radio" name="welcome_drink_type" value="iced_tea"> Iced tea</label>
+                    <label class="quote-addon-card__radio"><input type="radio" name="welcome_drink_type" value="berry"> Berry</label>
+                    <label class="quote-addon-card__radio"><input type="radio" name="welcome_drink_type" value="mint"> Mint</label>
+                  </div>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="amenity_kit" data-price="5000" data-type="per-person" data-label="Зочдын ариун цэврийн багц">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Зочдын ариун цэврийн багц</span>
+                  <span class="quote-addon-card__detail">Сойз, ОО, саван, шампунь</span>
+                  <span class="quote-addon-card__price">+5,000₮ / хүн</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="sleeping_bag" data-price="10000" data-type="per-person" data-label="Sleeping bag">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Sleeping bag</span>
+                  <span class="quote-addon-card__price">+10,000₮ / хүн</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="coffee_tea_corner" data-price="5000" data-type="per-person" data-label="Coffee &amp; tea corner">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Coffee &amp; tea corner</span>
+                  <span class="quote-addon-card__detail">07:30–09:00</span>
+                  <span class="quote-addon-card__price">+5,000₮ / хүн</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="lunch_upgrade" data-price="10000" data-type="per-person" data-label="Өдрийн buffet upgrade">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Өдрийн buffet upgrade</span>
+                  <span class="quote-addon-card__price">+10,000₮ / хүн</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="dinner_upgrade" data-price="10000" data-type="per-person" data-label="Оройн buffet upgrade">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Оройн buffet upgrade</span>
+                  <span class="quote-addon-card__price">+10,000₮ / хүн</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="late_night_snacks" data-price="8000" data-type="per-person" data-label="Late night snacks">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Late night snacks</span>
+                  <span class="quote-addon-card__detail">22:00–24:00</span>
+                  <span class="quote-addon-card__price">+8,000₮ / хүн</span>
+                </div>
+              </label>
+
+            </div>
+          </div>
+
+          <div class="quote-addons__group">
+            <h4 class="quote-addons__group-title">Тогтмол үнэтэй нэмэлтүүд</h4>
+            <div class="quote-addons__grid quote-addons__grid--flat">
+
+              <label class="quote-addon-card quote-addon-card--full">
+                <input type="checkbox" name="addons[]" value="dj_service" data-type="flat-dynamic" data-label="DJ service">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">DJ service</span>
+                  <div class="quote-addon-card__time-config" hidden>
+                    <div class="quote-addon-card__time-row">
+                      <label class="quote-addon-card__time-label">Эхлэх цаг:
+                        <select name="dj_start_time" class="quote-addon-card__select">
+                          <option value="18">18:00</option>
+                          <option value="19">19:00</option>
+                          <option value="20">20:00</option>
+                        </select>
+                      </label>
+                      <label class="quote-addon-card__time-label">Дуусах цаг:
+                        <select name="dj_end_time" class="quote-addon-card__select">
+                          <option value="21">21:00</option>
+                          <option value="22">22:00</option>
+                          <option value="23">23:00</option>
+                          <option value="24">24:00</option>
+                          <option value="25">01:00</option>
+                          <option value="26">02:00</option>
+                        </select>
+                      </label>
+                    </div>
+                  </div>
+                  <span class="quote-addon-card__price" data-dj-price>+1,000,000₮</span>
+                </div>
+              </label>
+
+              <label class="quote-addon-card quote-addon-card--full">
+                <input type="checkbox" name="addons[]" value="bartender_service" data-type="flat-auto" data-label="Bartender service">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Bartender service (3 цаг)</span>
+                  <span class="quote-addon-card__detail">Хүний тооноос хамаарч bartender тоо автомат тогтоогдоно</span>
+                  <span class="quote-addon-card__price" data-bartender-price>+500,000₮ (1 bartender)</span>
+                  <small class="quote-addon-card__tooltip">1 bartender / 75 зочин стандарт. Premium event-д илүү олон bartender хэрэгтэй бол sales баг тохирно.</small>
+                </div>
+              </label>
+
+              <label class="quote-addon-card">
+                <input type="checkbox" name="addons[]" value="photographer" data-price="500000" data-type="flat" data-label="Гэрэл зургийн үйлчилгээ">
+                <div class="quote-addon-card__body">
+                  <span class="quote-addon-card__name">Гэрэл зургийн үйлчилгээ (4 цаг)</span>
+                  <span class="quote-addon-card__price">+500,000₮</span>
+                </div>
+              </label>
+
+            </div>
+          </div>
+        </div>
+        <!-- ── /НЭМЭЛТ ҮЙЛЧИЛГЭЭ ──────────────────────────────── -->
+
         <div class="quote-form__field quote-form__field--full quote-form__field--conditional" id="location-field-wrap" aria-hidden="true" style="display:none">
           <label for="location">Кемп байгуулах байршил <span class="quote-form__required" aria-hidden="true">*</span></label>
           <small class="quote-form__helper-text">Аймаг, сум эсвэл Google Maps location оруулна уу</small>
@@ -978,6 +1115,7 @@
           <label for="extra-info">Нэмэлт мэдээлэл</label>
           <textarea id="extra-info" name="extra_info" rows="4"></textarea>
         </div>
+        <div class="quote-estimate quote-form__field--full" id="quote-estimate" hidden></div>
       </div>
       <div style="position:absolute;left:-9999px;opacity:0;pointer-events:none;" aria-hidden="true">
         <label for="field-website">Website</label>

--- a/main.js
+++ b/main.js
@@ -764,6 +764,14 @@
       if (modalTitleEl) modalTitleEl.textContent = 'Үнийн санал авах';
       applyLocationVisibility('');
       clearAllErrors();
+      // Reset add-on UI
+      quoteForm.querySelectorAll('input[name="addons[]"]').forEach(function (cb) { cb.checked = false; });
+      quoteForm.querySelectorAll('.quote-addon-card__time-config').forEach(function (el) { el.hidden = true; });
+      quoteForm.querySelectorAll('.quote-addon-card__sub-options').forEach(function (el) { el.hidden = true; });
+      var bartenderPriceEl = document.querySelector('[data-bartender-price]');
+      if (bartenderPriceEl) bartenderPriceEl.textContent = '+500,000₮ (1 bartender)';
+      var djPriceEl = document.querySelector('[data-dj-price]');
+      if (djPriceEl) djPriceEl.textContent = '+1,000,000₮';
     }
 
     // Clear inline errors on user input
@@ -803,12 +811,29 @@
       return n.toLocaleString('en-US') + '₮';
     }
 
+    function calculateDJPrice() {
+      var startEl = document.querySelector('[name="dj_start_time"]');
+      var endEl   = document.querySelector('[name="dj_end_time"]');
+      if (!startEl || !endEl) return 1000000;
+      var duration = parseInt(endEl.value, 10) - parseInt(startEl.value, 10);
+      if (duration <= 2) return 1000000;
+      if (duration === 3) return 1500000;
+      if (duration === 4) return 2000000;
+      if (duration === 5) return 2500000;
+      return 3000000;
+    }
+
+    function calculateBartenderPrice(guests) {
+      var count = Math.ceil(guests / 75) || 1;
+      return count * 500000;
+    }
+
     function updateEstimate() {
       if (!estimateEl) return;
-      var camp   = campSelect    ? campSelect.value              : '';
-      var tier   = tierSelect    ? tierSelect.value              : '';
-      var guests = guestInput    ? parseInt(guestInput.value, 10) : 0;
-      var shuttle = shuttleSelect ? shuttleSelect.value          : 'Сонгохгүй';
+      var camp    = campSelect    ? campSelect.value               : '';
+      var tier    = tierSelect    ? tierSelect.value               : '';
+      var guests  = guestInput    ? parseInt(guestInput.value, 10) : 0;
+      var shuttle = shuttleSelect ? shuttleSelect.value            : 'Сонгохгүй';
 
       if (!camp || !tier || !guests || guests < 1) {
         estimateEl.hidden = true;
@@ -832,12 +857,44 @@
 
       var base = perPerson * guests;
       var shuttleAmount = SHUTTLE_PRICE[shuttle] !== undefined ? SHUTTLE_PRICE[shuttle] : 0;
-      var total = base + shuttleAmount;
       var shuttleLabelText = SHUTTLE_LABEL[shuttle];
+
+      var perPersonAddonsSum = 0;
+      var flatAddonsSum = 0;
+      var addonRows = '';
+
+      document.querySelectorAll('input[name="addons[]"]:checked').forEach(function (cb) {
+        var type  = cb.dataset.type;
+        var label = cb.dataset.label || cb.value;
+        if (type === 'per-person') {
+          var ppPrice = parseInt(cb.dataset.price, 10);
+          perPersonAddonsSum += ppPrice;
+          addonRows += '<p class="quote-estimate__row">' + label + ': ' + formatMNT(ppPrice) + ' × ' + guests + ' = <span class="quote-estimate__num">' + formatMNT(ppPrice * guests) + '</span></p>';
+        } else if (type === 'flat-dynamic' && cb.value === 'dj_service') {
+          var djPrice = calculateDJPrice();
+          flatAddonsSum += djPrice;
+          addonRows += '<p class="quote-estimate__row">DJ service: <span class="quote-estimate__num">+' + formatMNT(djPrice) + '</span></p>';
+        } else if (type === 'flat-auto' && cb.value === 'bartender_service') {
+          var btPrice = calculateBartenderPrice(guests);
+          var btCount = Math.ceil(guests / 75) || 1;
+          flatAddonsSum += btPrice;
+          addonRows += '<p class="quote-estimate__row">Bartender (' + btCount + '): <span class="quote-estimate__num">+' + formatMNT(btPrice) + '</span></p>';
+        } else if (type === 'flat') {
+          var flatPrice = parseInt(cb.dataset.price, 10);
+          flatAddonsSum += flatPrice;
+          addonRows += '<p class="quote-estimate__row">' + label + ': <span class="quote-estimate__num">+' + formatMNT(flatPrice) + '</span></p>';
+        }
+      });
+
+      var total = base + (perPersonAddonsSum * guests) + flatAddonsSum + shuttleAmount;
 
       var html = '<p class="quote-estimate__title">Урьдчилсан тооцоолол</p>';
       html += '<p class="quote-estimate__row">' + tier + ' багц · ' + guests + ' хүн</p>';
       html += '<p class="quote-estimate__row">' + guests + ' × ' + formatMNT(perPerson) + ' = <span class="quote-estimate__num">' + formatMNT(base) + '</span></p>';
+      if (addonRows) {
+        html += '<p class="quote-estimate__row quote-estimate__row--addon-section">Нэмэлт үйлчилгээ:</p>';
+        html += addonRows;
+      }
       if (shuttleLabelText) {
         html += '<p class="quote-estimate__row">' + shuttleLabelText + ': <span class="quote-estimate__num">+' + formatMNT(shuttleAmount) + '</span></p>';
       }
@@ -849,6 +906,55 @@
 
     if (guestInput)    guestInput.addEventListener('input',   updateEstimate);
     if (shuttleSelect) shuttleSelect.addEventListener('change', updateEstimate);
+
+    // ── ADD-ON LISTENERS ───────────────────────────────────────
+    document.querySelectorAll('input[name="addons[]"]').forEach(function (cb) {
+      cb.addEventListener('change', updateEstimate);
+    });
+
+    var djStartSel = document.querySelector('[name="dj_start_time"]');
+    var djEndSel   = document.querySelector('[name="dj_end_time"]');
+    if (djStartSel) djStartSel.addEventListener('change', function () {
+      updateEstimate();
+      var priceEl = document.querySelector('[data-dj-price]');
+      if (priceEl) priceEl.textContent = '+' + calculateDJPrice().toLocaleString('en-US') + '₮';
+    });
+    if (djEndSel) djEndSel.addEventListener('change', function () {
+      updateEstimate();
+      var priceEl = document.querySelector('[data-dj-price]');
+      if (priceEl) priceEl.textContent = '+' + calculateDJPrice().toLocaleString('en-US') + '₮';
+    });
+
+    var djCb = document.querySelector('input[value="dj_service"]');
+    if (djCb) {
+      djCb.addEventListener('change', function (e) {
+        var timeConfig = e.target.closest('.quote-addon-card').querySelector('.quote-addon-card__time-config');
+        if (timeConfig) timeConfig.hidden = !e.target.checked;
+      });
+    }
+
+    var welcomeDrinkCb = document.querySelector('input[value="welcome_drink"]');
+    if (welcomeDrinkCb) {
+      welcomeDrinkCb.addEventListener('change', function (e) {
+        var subOptions = e.target.closest('.quote-addon-card').querySelector('.quote-addon-card__sub-options');
+        if (subOptions) subOptions.hidden = !e.target.checked;
+      });
+    }
+
+    if (guestInput) {
+      guestInput.addEventListener('input', function () {
+        var bartenderPriceEl = document.querySelector('[data-bartender-price]');
+        if (!bartenderPriceEl) return;
+        var g = parseInt(guestInput.value, 10);
+        if (!g || g < 1) {
+          bartenderPriceEl.textContent = '+500,000₮ (1 bartender)';
+          return;
+        }
+        var btCount = Math.ceil(g / 75);
+        bartenderPriceEl.textContent = '+' + (btCount * 500000).toLocaleString('en-US') + '₮ (' + btCount + ' bartender)';
+      });
+    }
+    // ── /ADD-ON LISTENERS ──────────────────────────────────────
 
     // Open modal from any quote trigger button
     quoteOpeners.forEach(function (link) {
@@ -952,6 +1058,40 @@
       var submitBtn = quoteForm.querySelector('[type="submit"]');
       if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Илгээж байна…'; }
 
+      var guestsInt = parseInt(guests, 10) || 0;
+      var selectedAddons = [];
+      quoteForm.querySelectorAll('input[name="addons[]"]:checked').forEach(function (cb) {
+        var item = {
+          code:  cb.value,
+          name:  cb.dataset.label || cb.value,
+          type:  cb.dataset.type  || 'unknown'
+        };
+        if (cb.value === 'dj_service') {
+          var djS = parseInt((document.querySelector('[name="dj_start_time"]') || {}).value, 10) || 18;
+          var djE = parseInt((document.querySelector('[name="dj_end_time"]')   || {}).value, 10) || 20;
+          item.start_time = djS + ':00';
+          item.end_time   = djE <= 24 ? djE + ':00' : (djE - 24) + ':00';
+          item.duration   = djE - djS;
+          item.price      = calculateDJPrice();
+        } else if (cb.value === 'bartender_service') {
+          item.bartender_count = Math.ceil(guestsInt / 75) || 1;
+          item.price           = calculateBartenderPrice(guestsInt);
+        } else if (cb.dataset.price) {
+          item.price = parseInt(cb.dataset.price, 10);
+        }
+        if (cb.value === 'welcome_drink') {
+          var drinkTypeEl = quoteForm.querySelector('input[name="welcome_drink_type"]:checked');
+          if (drinkTypeEl) item.drink_type = drinkTypeEl.value;
+        }
+        selectedAddons.push(item);
+      });
+
+      var addonEstimatedTotal = 0;
+      selectedAddons.forEach(function (a) {
+        if (a.type === 'per-person' && a.price) addonEstimatedTotal += a.price * guestsInt;
+        else if (a.price) addonEstimatedTotal += a.price;
+      });
+
       var payload = {
         camp:                  camp,
         tier:                  tier,
@@ -970,6 +1110,9 @@
         camp_name:             camp,
         package_tier:          tier,
         shuttle_service_label: (fd.get('shuttle_service') || '').trim(),
+        addons_json:           JSON.stringify(selectedAddons),
+        addon_count:           selectedAddons.length,
+        estimated_addon_total: addonEstimatedTotal,
         source:                'nomaadcamp.com'
       };
 

--- a/style.css
+++ b/style.css
@@ -3181,3 +3181,180 @@ body.home-page video {
     padding: 24px 16px;
   }
 }
+
+/* ── QUOTE MODAL ADD-ON SELECTOR ──────────────────────────── */
+.quote-addons-wrap {
+  padding: 0;
+}
+.quote-addons__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--primary-forest);
+  margin: 0 0 0.2rem;
+}
+.quote-addons__subtitle {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin: 0 0 1.1rem;
+}
+.quote-addons__group {
+  margin-bottom: 1.25rem;
+}
+.quote-addons__group-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--primary-forest);
+  margin: 0 0 0.6rem;
+  opacity: 0.7;
+}
+.quote-addons__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+
+/* Individual addon card */
+.quote-addon-card {
+  display: flex;
+  flex-direction: column;
+  border: 1.5px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  background: #fff;
+  position: relative;
+  user-select: none;
+}
+.quote-addon-card:hover {
+  border-color: var(--primary-forest);
+  background: #f4f7f4;
+}
+.quote-addon-card input[type="checkbox"] {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+  accent-color: var(--primary-forest);
+  flex-shrink: 0;
+}
+.quote-addon-card:has(input[type="checkbox"]:checked) {
+  border-color: var(--primary-forest);
+  background: #f0f5f0;
+}
+.quote-addon-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  padding-right: 1.6rem;
+}
+.quote-addon-card__name {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--primary-forest);
+  line-height: 1.3;
+}
+.quote-addon-card__detail {
+  font-size: 0.76rem;
+  color: #6b7280;
+  line-height: 1.35;
+}
+.quote-addon-card__price {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--primary-forest);
+  margin-top: 0.2rem;
+}
+.quote-addon-card__tooltip {
+  font-size: 0.7rem;
+  color: #6b7280;
+  margin-top: 0.3rem;
+  line-height: 1.45;
+  font-style: italic;
+}
+.quote-addon-card--full {
+  grid-column: 1 / -1;
+}
+
+/* DJ time picker */
+.quote-addon-card__time-config {
+  margin-top: 0.55rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid #e5e7eb;
+}
+.quote-addon-card__time-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.quote-addon-card__time-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--primary-forest);
+}
+.quote-addon-card__select {
+  font-size: 0.8rem;
+  padding: 0.28rem 0.45rem;
+  border: 1px solid #d1d5db;
+  border-radius: 5px;
+  background: #fff;
+  cursor: pointer;
+  color: var(--primary-forest);
+}
+
+/* Welcome drink sub-options */
+.quote-addon-card__sub-options {
+  margin-top: 0.55rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid #e5e7eb;
+}
+.quote-addon-card__sub-label {
+  display: block;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--primary-forest);
+  margin-bottom: 0.35rem;
+}
+.quote-addon-card__radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+}
+.quote-addon-card__radio {
+  display: flex;
+  align-items: center;
+  gap: 0.28rem;
+  font-size: 0.76rem;
+  cursor: pointer;
+  color: var(--primary-forest);
+}
+.quote-addon-card__radio input[type="radio"] {
+  position: static;
+  width: auto;
+  height: auto;
+  accent-color: var(--primary-forest);
+}
+
+.quote-estimate__row--addon-section {
+  font-weight: 600;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+/* Mobile: single column */
+@media (max-width: 600px) {
+  .quote-addons__grid {
+    grid-template-columns: 1fr;
+  }
+  .quote-addon-card--full {
+    grid-column: 1;
+  }
+}


### PR DESCRIPTION
Implements the full add-on selector section inside the quote modal as specified in issue #144.

Changes include:
- Add-on HTML section with 7 per-person and 3 flat-fee items
- Real-time pricing calculator with add-on breakdown
- DJ time picker + Bartender auto-scale logic
- CSS grid layout (2-col desktop, 1-col mobile)
- Add-on data in N8N webhook payload

Closes #144

Generated with [Claude Code](https://claude.ai/code)