### PR TITLE
feat(addons): hide production-only sections, info-only display, tier upgrade nudge

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,12 +232,14 @@
               <li>Team activities</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Тусгайлан тооцоолох үйлчилгээ</p>
-            <ul class="pkg-choices">
+            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
               <li>Нэмэлт асар, майхан</li>
+              <li>Нэмэлт тоног төхөөрөмжийн түрээс</li>
             </ul>
+            <small class="pkg-features__custom-note">Хэрэгцээ шаардлагаас хамаарч тус бүр санал боловсруулна.</small>
             <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
@@ -364,12 +366,14 @@
               <li class="pkg-features__highlight">🎁 LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Тусгайлан тооцоолох үйлчилгээ</p>
-            <ul class="pkg-choices">
+            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
               <li>Нэмэлт асар, майхан</li>
+              <li>Нэмэлт тоног төхөөрөмжийн түрээс</li>
             </ul>
+            <small class="pkg-features__custom-note">Хэрэгцээ шаардлагаас хамаарч тус бүр санал боловсруулна.</small>
             <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
@@ -496,12 +500,14 @@
               <li class="pkg-features__highlight">🎁 LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Тусгайлан тооцоолох үйлчилгээ</p>
-            <ul class="pkg-choices">
+            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
               <li>Нэмэлт асар, майхан</li>
+              <li>Нэмэлт тоног төхөөрөмжийн түрээс</li>
             </ul>
+            <small class="pkg-features__custom-note">Хэрэгцээ шаардлагаас хамаарч тус бүр санал боловсруулна.</small>
             <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
@@ -626,12 +632,14 @@
               <li>Team activities</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <p class="pkg-choice-label">Тусгайлан тооцоолох үйлчилгээ</p>
-            <ul class="pkg-choices">
+            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
               <li>Нэмэлт асар, майхан</li>
+              <li>Нэмэлт тоног төхөөрөмжийн түрээс</li>
             </ul>
+            <small class="pkg-features__custom-note">Хэрэгцээ шаардлагаас хамаарч тус бүр санал боловсруулна.</small>
             <div class="pkg-divider" aria-hidden="true"></div>
             <div class="pkg-accordion">
               <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
@@ -1185,61 +1193,66 @@
             </div>
           </div>
 
-          <div class="quote-addons__group">
+          <div class="quote-addons__group quote-addons__group--per-event">
             <h4 class="quote-addons__group-title">Event-д тооцох үйлчилгээ</h4>
-            <div class="quote-addons__grid quote-addons__grid--per-event">
+            <div class="quote-addons__grid">
 
-              <label class="quote-addon-card">
-                <input type="checkbox" name="addons[]" value="medical_service" data-type="per-event-auto-medical" data-label="Анхан шатны эмнэлгийн тусламж">
+              <div class="quote-addon-card quote-addon-card--info">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">Анхан шатны эмнэлгийн тусламж</span>
+                  <span class="quote-addon-card__name">
+                    Анхан шатны эмнэлгийн тусламж
+                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
+                  </span>
                   <span class="quote-addon-card__detail">1 эмч сувилагч + medical асар</span>
-                  <span class="quote-addon-card__price" data-medical-price>+1,000,000₮</span>
                 </div>
-              </label>
+              </div>
 
-              <label class="quote-addon-card">
-                <input type="checkbox" name="addons[]" value="security_service" data-type="per-event-auto-security" data-label="Хамгаалалтын алба">
+              <div class="quote-addon-card quote-addon-card--info">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">Хамгаалалтын алба</span>
+                  <span class="quote-addon-card__name">
+                    Хамгаалалтын алба
+                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
+                  </span>
                   <span class="quote-addon-card__detail">2 officer continuous coverage минимум</span>
-                  <span class="quote-addon-card__price" data-security-price>+1,000,000₮</span>
                 </div>
-              </label>
+              </div>
 
             </div>
           </div>
 
-          <div class="quote-addons__group">
+          <div class="quote-addons__group quote-addons__group--production">
             <h4 class="quote-addons__group-title">Production үйлчилгээ</h4>
-            <div class="quote-addons__grid quote-addons__grid--production">
+            <div class="quote-addons__grid">
 
-              <label class="quote-addon-card">
-                <input type="checkbox" name="addons[]" value="program_design" data-type="flat" data-label="Хөтөлбөр боловсруулах">
+              <div class="quote-addon-card quote-addon-card--info">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">Хөтөлбөр боловсруулах</span>
+                  <span class="quote-addon-card__name">
+                    Хөтөлбөр боловсруулах
+                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
+                  </span>
                   <span class="quote-addon-card__detail">Арга хэмжээний хөтөлбөр хамтран боловсруулах</span>
-                  <span class="quote-addon-card__price">Үнэ тохирно</span>
                 </div>
-              </label>
+              </div>
 
-              <label class="quote-addon-card">
-                <input type="checkbox" name="addons[]" value="onsite_coordination" data-type="flat" data-label="On-site coordination">
+              <div class="quote-addon-card quote-addon-card--info">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">On-site coordination</span>
+                  <span class="quote-addon-card__name">
+                    On-site coordination
+                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
+                  </span>
                   <span class="quote-addon-card__detail">Хөтөлбөрийн дагуу нэгдсэн байдлаар удирдах</span>
-                  <span class="quote-addon-card__price">Үнэ тохирно</span>
                 </div>
-              </label>
+              </div>
 
-              <label class="quote-addon-card">
-                <input type="checkbox" name="addons[]" value="team_activities" data-type="flat" data-label="Team activities">
+              <div class="quote-addon-card quote-addon-card--info">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">Team activities</span>
+                  <span class="quote-addon-card__name">
+                    Team activities
+                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
+                  </span>
                   <span class="quote-addon-card__detail">Багийн уур амьсгал дэмжих тоглоом, өрсөлдөөн</span>
-                  <span class="quote-addon-card__price">Үнэ тохирно</span>
                 </div>
-              </label>
+              </div>
 
             </div>
           </div>

--- a/main.js
+++ b/main.js
@@ -846,8 +846,6 @@
         'lunch_upgrade', 'dinner_upgrade',
         'moonbeam_lounge', 'dj_service', 'photo_4h',
         'amenity_kit', 'bartender_service',
-        'medical_service', 'security_service',
-        'program_design', 'onsite_coordination', 'team_activities',
         'led_screen_18m2'
       ]
     };
@@ -911,6 +909,18 @@
       return tier ? tier.price : 195000;
     }
 
+    function toggleProductionOnlySections(tier) {
+      var eventServicesSection = document.querySelector('.quote-addons__group--per-event');
+      var productionServicesSection = document.querySelector('.quote-addons__group--production');
+      if (tier === 'Production') {
+        if (eventServicesSection) eventServicesSection.style.display = '';
+        if (productionServicesSection) productionServicesSection.style.display = '';
+      } else {
+        if (eventServicesSection) eventServicesSection.style.display = 'none';
+        if (productionServicesSection) productionServicesSection.style.display = 'none';
+      }
+    }
+
     function applyTierInclusions(tier) {
       var campName = campSelect ? campSelect.value : '';
       var includedItems = getTierInclusions(campName, tier);
@@ -942,6 +952,7 @@
           if (existingBadge) existingBadge.remove();
         }
       });
+      toggleProductionOnlySections(tier);
     }
 
     function updateAutoScaleLabels(guests) {

--- a/style.css
+++ b/style.css
@@ -3461,6 +3461,45 @@ body.home-page video {
   margin-left: -1.25rem;
 }
 
+/* Info-only addon card (Production-included services shown without checkbox) */
+.quote-addon-card--info {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.08);
+  cursor: default;
+  padding: 1rem 1.25rem;
+}
+.quote-addon-card--info .quote-addon-card__name {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+/* Production tier card sub-section */
+.pkg-features__sub-title {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(0, 0, 0, 0.55);
+}
+.pkg-features--secondary {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.65);
+}
+.pkg-features--secondary li {
+  font-style: italic;
+}
+.pkg-features__custom-note {
+  display: block;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(0, 0, 0, 0.03);
+  border-left: 3px solid rgba(0, 0, 0, 0.15);
+  font-size: 0.8rem;
+  font-style: italic;
+  color: rgba(0, 0, 0, 0.65);
+}
+
 /* Tier upgrade nudge */
 .quote-tier-nudge {
   margin-top: 1.5rem;


### PR DESCRIPTION
Closes #152

Implements remaining changes from issue #152:

- `toggleProductionOnlySections(tier)` function: hides Event & Production service sections for Essential/Experience, shows them for Production
- Restructured Event-only & Production-only addon sections to info-only divs with "Production багцад багтсан" badge (no checkbox, no price)
- Removed medical/security/program/coordination/activities from TIER_INCLUSIONS (now info-only display)
- Added CSS: .quote-addon-card--info, .pkg-features__sub-title, .pkg-features--secondary, .pkg-features__custom-note
- Updated all 4 Production tier cards: "Тусгайлан тооцоолох" sub-section now uses new CSS classes + custom note

Generated with [Claude Code](https://claude.ai/code)