### PR TITLE
feat(addons): refine pricing structure with Moonbeam, LED screen, Bartender in Experience, popular badge, Production-only sections, tier upgrade nudge with savings

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
             <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
+            <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">350,000₮<span class="pkg-per"> / хүн</span></div>
@@ -176,11 +176,8 @@
               <li>Sleeping bag</li>
               <li>Coffee &amp; tea corner</li>
               <li>Өдөр болон оройн buffet upgrade</li>
-              <li>Moonbeam Lounge — гэрэлтдэг bar тек + bartender 3 цаг
-                <small class="pkg-features__note">Алкохол, орц материалыг хэрэглэгч авч ирнэ</small>
-              </li>
-              <li>DJ service (3 цаг)</li>
-              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Moonbeam Lounge — гэрэлтдэг bar тек</li>
+              <li>Bartender үйлчилгээ (3 цаг)</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <p class="pkg-choice-label">Arrival welcome drink сонголт</p>
@@ -224,12 +221,16 @@
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>Зочдын ариун цэврийн багц</li>
-              <li>Bartender service</li>
-              <li>Эмнэлгийн тусламж</li>
-              <li>Хамгаалалтын алба</li>
+              <li>DJ service (3 цаг)</li>
+              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Эмнэлгийн тусламж (асар + 1 эмч)</li>
+              <li>Хамгаалалтын алба (минимум 2 officer)</li>
               <li>Хөтөлбөр боловсруулах</li>
               <li>On-site coordination</li>
               <li>Team activities</li>
+              <li class="pkg-features__highlight">
+                🎁 LED дэлгэц 18м²
+              </li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
@@ -297,7 +298,7 @@
             <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
+            <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -309,11 +310,8 @@
               <li>Sleeping bag</li>
               <li>Coffee &amp; tea corner</li>
               <li>Өдөр болон оройн buffet upgrade</li>
-              <li>Moonbeam Lounge — гэрэлтдэг bar тек + bartender 3 цаг
-                <small class="pkg-features__note">Алкохол, орц материалыг хэрэглэгч авч ирнэ</small>
-              </li>
-              <li>DJ service (3 цаг)</li>
-              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Moonbeam Lounge — гэрэлтдэг bar тек</li>
+              <li>Bartender үйлчилгээ (3 цаг)</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <p class="pkg-choice-label">Arrival welcome drink сонголт</p>
@@ -357,13 +355,16 @@
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>Зочдын ариун цэврийн багц</li>
-              <li>Bartender service (нэмэлт, хэрэгцээт тоо)</li>
+              <li>DJ service (3 цаг)</li>
+              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
               <li>Эмнэлгийн тусламж (асар + 1 эмч)</li>
               <li>Хамгаалалтын алба (минимум 2 officer)</li>
               <li>Хөтөлбөр боловсруулах</li>
               <li>On-site coordination</li>
               <li>Team activities</li>
-              <li class="pkg-features__highlight">🎁 LED дэлгэц 18м²</li>
+              <li class="pkg-features__highlight">
+                🎁 LED дэлгэц 18м²
+              </li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
@@ -431,7 +432,7 @@
             <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
+            <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -443,11 +444,8 @@
               <li>Sleeping bag</li>
               <li>Coffee &amp; tea corner</li>
               <li>Өдөр болон оройн buffet upgrade</li>
-              <li>Moonbeam Lounge — гэрэлтдэг bar тек + bartender 3 цаг
-                <small class="pkg-features__note">Алкохол, орц материалыг хэрэглэгч авч ирнэ</small>
-              </li>
-              <li>DJ service (3 цаг)</li>
-              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Moonbeam Lounge — гэрэлтдэг bar тек</li>
+              <li>Bartender үйлчилгээ (3 цаг)</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <p class="pkg-choice-label">Arrival welcome drink сонголт</p>
@@ -491,13 +489,16 @@
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>Зочдын ариун цэврийн багц</li>
-              <li>Bartender service (нэмэлт, хэрэгцээт тоо)</li>
+              <li>DJ service (3 цаг)</li>
+              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
               <li>Эмнэлгийн тусламж (асар + 1 эмч)</li>
               <li>Хамгаалалтын алба (минимум 2 officer)</li>
               <li>Хөтөлбөр боловсруулах</li>
               <li>On-site coordination</li>
               <li>Team activities</li>
-              <li class="pkg-features__highlight">🎁 LED дэлгэц 18м²</li>
+              <li class="pkg-features__highlight">
+                🎁 LED дэлгэц 18м²
+              </li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
@@ -565,7 +566,7 @@
             <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
-            <span class="pkg-badge" aria-label="Хамгийн их сонгогдсон">Эрэлттэй багц</span>
+            <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
             <div class="pkg-header">
               <span class="pkg-tier-label">Experience</span>
               <div class="pkg-price">220,000₮<span class="pkg-per"> / хүн</span></div>
@@ -577,11 +578,8 @@
               <li>Sleeping bag</li>
               <li>Coffee &amp; tea corner</li>
               <li>Өдөр болон оройн buffet upgrade</li>
-              <li>Moonbeam Lounge — гэрэлтдэг bar тек + bartender 3 цаг
-                <small class="pkg-features__note">Алкохол, орц материалыг хэрэглэгч авч ирнэ</small>
-              </li>
-              <li>DJ service (3 цаг)</li>
-              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Moonbeam Lounge — гэрэлтдэг bar тек</li>
+              <li>Bartender үйлчилгээ (3 цаг)</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <p class="pkg-choice-label">Arrival welcome drink сонголт</p>
@@ -624,12 +622,16 @@
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>Зочдын ариун цэврийн багц</li>
-              <li>Bartender service</li>
-              <li>Эмнэлгийн тусламж</li>
-              <li>Хамгаалалтын алба</li>
+              <li>DJ service (3 цаг)</li>
+              <li>Гэрэл зургийн үйлчилгээ (4 цаг)</li>
+              <li>Эмнэлгийн тусламж (асар + 1 эмч)</li>
+              <li>Хамгаалалтын алба (минимум 2 officer)</li>
               <li>Хөтөлбөр боловсруулах</li>
               <li>On-site coordination</li>
               <li>Team activities</li>
+              <li class="pkg-features__highlight">
+                🎁 LED дэлгэц 18м²
+              </li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
             <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
@@ -1156,29 +1158,28 @@
               </label>
 
               <label class="quote-addon-card" data-addon-code="moonbeam_lounge">
-                <input type="checkbox" name="addons[]" value="moonbeam_lounge" data-price="1000000" data-type="flat" data-label="Moonbeam Lounge package">
+                <input type="checkbox" name="addons[]" value="moonbeam_lounge" data-price="500000" data-type="flat" data-label="Moonbeam Lounge">
                 <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">Moonbeam Lounge package</span>
+                  <span class="quote-addon-card__name">Moonbeam Lounge</span>
                   <span class="quote-addon-card__detail">
-                    Гэрэлтдэг bar тек, ambient lighting, premium glassware<br>
-                    Bartender 3 цаг welcome service
+                    Гэрэлтдэг bar тек, ambient lighting, premium glassware
                   </span>
                   <span class="quote-addon-card__client-supplied">
                     Алкохол, жүүс, орц материалыг хэрэглэгч авч ирнэ
                   </span>
-                  <span class="quote-addon-card__price">+1,000,000₮</span>
+                  <span class="quote-addon-card__price">+500,000₮</span>
                 </div>
               </label>
 
               <label class="quote-addon-card" data-addon-code="led_screen_18m2">
-                <input type="checkbox" name="addons[]" value="led_screen_18m2" data-price="2160000" data-type="flat" data-label="LED дэлгэц 18м²">
+                <input type="checkbox" name="addons[]" value="led_screen_18m2" data-price="1728000" data-type="flat" data-label="LED дэлгэц 18м²">
                 <div class="quote-addon-card__body">
                   <span class="quote-addon-card__name">LED дэлгэц 18м²</span>
                   <span class="quote-addon-card__detail">
                     6м × 3м high-resolution LED display<br>
                     Stage backdrop эсвэл main screen
                   </span>
-                  <span class="quote-addon-card__price">+2,160,000₮</span>
+                  <span class="quote-addon-card__price">+1,728,000₮</span>
                 </div>
               </label>
 
@@ -1297,6 +1298,16 @@
             <button type="button" class="btn btn--accent quote-tier-nudge__cta" data-tier-switch>
               <span data-target-tier>Experience</span> tier-руу шилжих →
             </button>
+          </div>
+        </div>
+
+        <div class="quote-production-link" id="production-link" hidden>
+          <div class="quote-production-link__icon">💡</div>
+          <div class="quote-production-link__body">
+            Илүү том хэмжээний арга хэмжээ төлөвлөж байна уу?
+            <a href="#production-section" class="quote-production-link__cta">
+              Production үйлчилгээний талаар үзэх →
+            </a>
           </div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -839,13 +839,13 @@
       'Experience': [
         'welcome_drink', 'sleeping_bag', 'coffee_corner',
         'lunch_upgrade', 'dinner_upgrade',
-        'moonbeam_lounge', 'dj_service', 'photo_4h'
+        'moonbeam_lounge', 'bartender_service'
       ],
       'Production': [
         'welcome_drink', 'sleeping_bag', 'coffee_corner',
         'lunch_upgrade', 'dinner_upgrade',
-        'moonbeam_lounge', 'dj_service', 'photo_4h',
-        'amenity_kit', 'bartender_service',
+        'moonbeam_lounge', 'bartender_service',
+        'amenity_kit', 'dj_service', 'photo_4h',
         'led_screen_18m2'
       ]
     };
@@ -997,6 +997,8 @@
         estimateEl.hidden = true;
         var nudgeEl2 = document.getElementById('tier-nudge');
         if (nudgeEl2) nudgeEl2.hidden = true;
+        var prodLinkEl = document.getElementById('production-link');
+        if (prodLinkEl) prodLinkEl.hidden = true;
         return;
       }
 
@@ -1182,13 +1184,16 @@
       var currentTier = tierSelect ? tierSelect.value : '';
       var campName = campSelect ? campSelect.value : '';
       var nudge = document.getElementById('tier-nudge');
+      var productionLink = document.getElementById('production-link');
       if (!nudge || !currentTier || !campName || guests < 1) {
         if (nudge) nudge.hidden = true;
+        if (productionLink) productionLink.hidden = true;
         return;
       }
 
       if (currentTier === 'Production') {
         nudge.hidden = true;
+        if (productionLink) productionLink.hidden = true;
         return;
       }
 
@@ -1222,6 +1227,7 @@
             currentTotal: currentTotal,
             bonusItems: bonusItems
           });
+          if (productionLink) productionLink.hidden = true;
           return;
         }
       }
@@ -1243,6 +1249,7 @@
       }
 
       nudge.hidden = true;
+      if (productionLink) productionLink.hidden = false;
     }
 
     function showNudge(opts) {

--- a/style.css
+++ b/style.css
@@ -3545,3 +3545,30 @@ body.home-page video {
 .quote-tier-nudge__cta {
   margin-top: 0.5rem;
 }
+.pkg-badge--popular {
+  background: var(--accent, #FF6A00);
+  color: #fff;
+}
+.quote-production-link {
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+.quote-production-link__icon {
+  font-size: 1.5rem;
+}
+.quote-production-link__body {
+  flex: 1;
+  font-size: 0.9rem;
+}
+.quote-production-link__cta {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--accent, #C75D2C);
+  font-weight: 600;
+  text-decoration: none;
+}


### PR DESCRIPTION
Fixes #154

## Changes

- Moonbeam Lounge: 500,000₮ (was 1,000,000₮), removed bartender from detail
- LED screen: 1,728,000₮ (was 2,160,000₮)
- TIER_INCLUSIONS: Experience now includes bartender_service instead of dj/photo; Production includes all
- Experience feature list updated for all 4 camps (Moonbeam + Bartender, no DJ/photo)
- Production feature list updated for all 4 camps (added DJ/photo, removed Bartender item)
- Experience badge: "Хамгийн их сонгогддог" with pkg-badge--popular class
- Added production-link HTML + CSS + JS visibility logic

Generated with [Claude Code](https://claude.ai/code)