### PR TITLE
fix(quote-modal): replace info-only cards with compact list for Production-included services

### DIFF
--- a/index.html
+++ b/index.html
@@ -1183,68 +1183,40 @@
             </div>
           </div>
 
-          <div class="quote-addons__group quote-addons__group--per-event">
-            <h4 class="quote-addons__group-title">Event-д тооцох үйлчилгээ</h4>
-            <div class="quote-addons__grid">
-
-              <div class="quote-addon-card quote-addon-card--info">
-                <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">
-                    Анхан шатны эмнэлгийн тусламж
-                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
-                  </span>
-                  <span class="quote-addon-card__detail">1 эмч сувилагч + medical асар</span>
-                </div>
-              </div>
-
-              <div class="quote-addon-card quote-addon-card--info">
-                <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">
-                    Хамгаалалтын алба
-                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
-                  </span>
-                  <span class="quote-addon-card__detail">2 officer continuous coverage минимум</span>
-                </div>
-              </div>
-
-            </div>
-          </div>
-
-          <div class="quote-addons__group quote-addons__group--production">
-            <h4 class="quote-addons__group-title">Production үйлчилгээ</h4>
-            <div class="quote-addons__grid">
-
-              <div class="quote-addon-card quote-addon-card--info">
-                <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">
-                    Хөтөлбөр боловсруулах
-                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
-                  </span>
-                  <span class="quote-addon-card__detail">Арга хэмжээний хөтөлбөр хамтран боловсруулах</span>
-                </div>
-              </div>
-
-              <div class="quote-addon-card quote-addon-card--info">
-                <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">
-                    On-site coordination
-                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
-                  </span>
-                  <span class="quote-addon-card__detail">Хөтөлбөрийн дагуу нэгдсэн байдлаар удирдах</span>
-                </div>
-              </div>
-
-              <div class="quote-addon-card quote-addon-card--info">
-                <div class="quote-addon-card__body">
-                  <span class="quote-addon-card__name">
-                    Team activities
-                    <span class="quote-addon-card__included-badge">Production багцад багтсан</span>
-                  </span>
-                  <span class="quote-addon-card__detail">Багийн уур амьсгал дэмжих тоглоом, өрсөлдөөн</span>
-                </div>
-              </div>
-
-            </div>
+          <div class="quote-addons__group quote-addons__group--production-included">
+            <h4 class="quote-addons__group-title">Production багцад багтсан үйлчилгээ</h4>
+            <ul class="quote-production-included-list">
+              <li>
+                <span class="quote-production-included-list__check">✓</span>
+                <span class="quote-production-included-list__text">
+                  <strong>Анхан шатны эмнэлгийн тусламж</strong> — эмч, сувилагч + анхан шатны тусламжын асар
+                </span>
+              </li>
+              <li>
+                <span class="quote-production-included-list__check">✓</span>
+                <span class="quote-production-included-list__text">
+                  <strong>Хамгаалалтын алба</strong> — багадаа 2 хамгаалалтын ажилтан
+                </span>
+              </li>
+              <li>
+                <span class="quote-production-included-list__check">✓</span>
+                <span class="quote-production-included-list__text">
+                  <strong>Хөтөлбөр боловсруулах</strong>
+                </span>
+              </li>
+              <li>
+                <span class="quote-production-included-list__check">✓</span>
+                <span class="quote-production-included-list__text">
+                  <strong>Хөтөлбөрийн дагуу үйл ажиллагааг удирдах</strong>
+                </span>
+              </li>
+              <li>
+                <span class="quote-production-included-list__check">✓</span>
+                <span class="quote-production-included-list__text">
+                  <strong>Багын уур амьсгал сайжруулах хөгжөөнт тоглоом</strong>
+                </span>
+              </li>
+            </ul>
           </div>
         </div>
         <!-- ── /НЭМЭЛТ ҮЙЛЧИЛГЭЭ ──────────────────────────────── -->

--- a/main.js
+++ b/main.js
@@ -895,14 +895,12 @@
     }
 
     function toggleProductionOnlySections(tier) {
-      var eventServicesSection = document.querySelector('.quote-addons__group--per-event');
-      var productionServicesSection = document.querySelector('.quote-addons__group--production');
+      const productionIncludedSection = document.querySelector('.quote-addons__group--production-included');
+
       if (tier === 'Production') {
-        if (eventServicesSection) eventServicesSection.style.display = '';
-        if (productionServicesSection) productionServicesSection.style.display = '';
+        if (productionIncludedSection) productionIncludedSection.style.display = '';
       } else {
-        if (eventServicesSection) eventServicesSection.style.display = 'none';
-        if (productionServicesSection) productionServicesSection.style.display = 'none';
+        if (productionIncludedSection) productionIncludedSection.style.display = 'none';
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -3472,6 +3472,60 @@ body.home-page video {
   color: rgba(0, 0, 0, 0.75);
 }
 
+/* Production included compact list */
+.quote-addons__group--production-included {
+  margin: 1.5rem 0;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 106, 0, 0.04) 0%, rgba(255, 106, 0, 0.08) 100%);
+  border: 1px solid rgba(255, 106, 0, 0.15);
+  border-radius: 10px;
+}
+
+.quote-addons__group--production-included .quote-addons__group-title {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent, #C75D2C);
+}
+
+.quote-production-included-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.quote-production-included-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.4rem 0;
+  font-size: 0.92rem;
+  color: rgba(0, 0, 0, 0.78);
+  line-height: 1.5;
+}
+
+.quote-production-included-list__check {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent, #FF6A00);
+  color: #fff;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 700;
+  margin-top: 0.15rem;
+}
+
+.quote-production-included-list__text strong {
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.92);
+}
+
 /* Production tier card sub-section */
 .pkg-features__sub-title {
   margin-top: 1rem;


### PR DESCRIPTION
Removed the two old card-style sections and replaced them with a single compact list section showing all 5 Production-included services with orange checkmark icons.

Closes #168

Generated with [Claude Code](https://claude.ai/code)