### PR TITLE
style: improve card visuals and gallery placeholder

### DIFF
--- a/style.css
+++ b/style.css
@@ -3671,3 +3671,108 @@ body.home-page video {
   from { opacity: 1; }
   to   { opacity: 0; }
 }
+
+/* ── VISUAL IMPROVEMENTS (Issue #170) ───────────────────────────────
+   Camp card 4:3 images · package card hierarchy · gallery placeholder.
+   All additive overrides — no structural edits to prior rules.
+   ──────────────────────────────────────────────────────────────── */
+
+/* ─ 1. Camp cards: consistent 4:3 image aspect-ratio ─ */
+/* Override all fixed-height declarations for the image and its overlay pseudo-elements */
+.camp-card img,
+.camp-card::after,
+.camp-card::before {
+  height: auto;
+  aspect-ratio: 4 / 3;
+}
+/* Reset responsive height overrides so 4:3 holds at every breakpoint */
+@media (max-width: 768px) {
+  .camp-card img,
+  .camp-card::after,
+  .camp-card::before {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+}
+@media (max-width: 560px) {
+  .camp-card img,
+  .camp-card::after,
+  .camp-card::before {
+    height: auto;
+    aspect-ratio: 4 / 3;
+  }
+}
+
+/* ─ 2. Camp cards: equal height via grid stretch + premium hover ─ */
+.camp-grid {
+  align-items: stretch;
+}
+.camp-card {
+  height: 100%;
+}
+.camp-card:hover {
+  border-color: rgba(31, 42, 35, 0.22);
+  box-shadow: 0 18px 44px rgba(31, 42, 35, 0.13), 0 2px 8px rgba(31, 42, 35, 0.04);
+}
+
+/* ─ 3. Package cards: Experience tier visible standout ─ */
+.pkg-card--featured {
+  background: linear-gradient(160deg, rgba(198, 93, 46, 0.05) 0%, var(--card-bg) 50%);
+}
+.pkg-card--featured .pkg-price {
+  color: var(--accent);
+}
+
+/* ─ 4. Package cards: feature list row separators for easier scanning ─ */
+.pkg-features li {
+  padding: 0.4rem 0;
+  border-bottom: 1px solid rgba(31, 42, 35, 0.055);
+}
+.pkg-features li:last-child {
+  border-bottom: none;
+}
+/* Secondary (custom) feature list: no separators, more compact */
+.pkg-features--secondary li {
+  border-bottom: none;
+  padding: 0.18rem 0;
+}
+
+/* ─ 5. Add-on accordion: visually secondary without harming contrast ─ */
+.pkg-accordion__toggle {
+  font-size: 0.72rem;
+  letter-spacing: 0.01em;
+}
+.pkg-accordion__line {
+  font-size: 0.76rem;
+}
+
+/* ─ 6. Gallery placeholder: intentional placeholder design ─ */
+.camp-gallery__viewport.is-empty {
+  border: 1px dashed rgba(31, 42, 35, 0.2);
+  background: rgba(245, 241, 232, 0.45);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 72px;
+}
+.camp-gallery__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 1.4rem 2rem;
+  gap: 0.2rem;
+}
+.camp-gallery__empty p {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(31, 42, 35, 0.48);
+  margin: 0;
+  letter-spacing: 0.025em;
+}
+.camp-gallery__empty small {
+  font-size: 0.68rem;
+  color: rgba(31, 42, 35, 0.34);
+  line-height: 1.5;
+}


### PR DESCRIPTION
Closes #170

Visual improvements to camp selection cards, package cards, add-on accordion, and gallery placeholder. CSS-only patch (+105 lines appended to style.css).

Generated with [Claude Code](https://claude.ai/code)