### PR TITLE
fix: content consistency and Production package clarity improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
   <div class="container hero-inner">
     <span class="eyebrow"><span class="eyebrow-dot"></span>Байгууллагын арга хэмжээний нэгдсэн үйлчилгээ</span>
     <h1>Зөвхөн танай байгууллагад зориулсан<br>кемпийн бүрэн шийдэл</h1>
-    <p class="hero-sub">30-аас 1000 хүний арга хэмжээг бэлтгэлээс гүйцэтгэл хүртэл нэгдсэн байдлаар зохион байгуулна. Хаалттай, зөвхөн танай байгууллагад зориулсан орчин.</p>
+    <p class="hero-sub">10-аас 1000 хүний арга хэмжээг бэлтгэлээс гүйцэтгэл хүртэл нэгдсэн байдлаар зохион байгуулна. Хаалттай, зөвхөн танай байгууллагад зориулсан орчин.</p>
     <div class="hero-actions">
       <a class="btn btn--accent btn--lg" href="#camps">Кемпүүд үзэх</a>
       <a class="btn btn--ghost-light btn--lg" href="#midweek">Өдрийн хөтөлбөр үзэх</a>
@@ -76,7 +76,7 @@
     <div class="hero-meta">
       <span>УБ-аас 75 км</span>
       <span aria-hidden="true">·</span>
-      <span>30–1000 хүн</span>
+      <span>10–1000 хүн</span>
       <span aria-hidden="true">·</span>
       <span>Бүрэн зохион байгуулалт</span>
     </div>
@@ -100,7 +100,7 @@
           <h3>A Кемп</h3>
           <p class="camp-size">200–1000 хүн</p>
           <p>Том хэмжээний байгууллагын арга хэмжээ, өдөрлөг, ойн баярт зориулсан.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-b">
@@ -109,7 +109,7 @@
           <h3>B Кемп</h3>
           <p class="camp-size">50–300 хүн</p>
           <p>Баг, алба нэгжийн сургалт, багийн идэвхжүүлэлт болон дотоод арга хэмжээнд.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-c">
@@ -118,7 +118,7 @@
           <h3>C Кемп</h3>
           <p class="camp-size">10–50 хүн</p>
           <p>Удирдлагын баг, стратегийн уулзалт, төвлөрсөн ажлын хөтөлбөрт.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-mobile">
@@ -127,7 +127,7 @@
           <h3>Нүүдлийн кемп</h3>
           <p class="camp-size">Хүссэн байршилд</p>
           <p>Танай сонгосон байршилд иж бүрэн кемп зохион байгуулна.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
     </div>
@@ -214,9 +214,10 @@
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price">280,000₮<span class="pkg-per"> / хүн</span></div>
+              <div class="pkg-price">280,000₮-аас<span class="pkg-per"> / хүн</span></div>
             </div>
-            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн үйлчилгээний зохион байгуулалт.</p>
+            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн зохион байгуулалт.</p>
+            <p class="pkg-note">Энэхүү үнэ нь суурь багцын үнэ бөгөөд арга хэмжээний онцлогоос хамаарч нэмэлт үйлчилгээ тусдаа тооцогдоно.</p>
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>DJ service (3 цаг)</li>
@@ -230,7 +231,7 @@
               <li>LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <h4 class="pkg-features__sub-title">Тусдаа тооцогдоно</h4>
             <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
@@ -345,9 +346,10 @@
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price">280,000₮<span class="pkg-per"> / хүн</span></div>
+              <div class="pkg-price">280,000₮-аас<span class="pkg-per"> / хүн</span></div>
             </div>
-            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн үйлчилгээний зохион байгуулалт.</p>
+            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн зохион байгуулалт.</p>
+            <p class="pkg-note">Энэхүү үнэ нь суурь багцын үнэ бөгөөд арга хэмжээний онцлогоос хамаарч нэмэлт үйлчилгээ тусдаа тооцогдоно.</p>
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>DJ service (3 цаг)</li>
@@ -361,7 +363,7 @@
               <li>LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <h4 class="pkg-features__sub-title">Тусдаа тооцогдоно</h4>
             <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
@@ -476,9 +478,10 @@
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price">280,000₮<span class="pkg-per"> / хүн</span></div>
+              <div class="pkg-price">280,000₮-аас<span class="pkg-per"> / хүн</span></div>
             </div>
-            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн үйлчилгээний зохион байгуулалт.</p>
+            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн зохион байгуулалт.</p>
+            <p class="pkg-note">Энэхүү үнэ нь суурь багцын үнэ бөгөөд арга хэмжээний онцлогоос хамаарч нэмэлт үйлчилгээ тусдаа тооцогдоно.</p>
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>DJ service (3 цаг)</li>
@@ -492,7 +495,7 @@
               <li>LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <h4 class="pkg-features__sub-title">Тусдаа тооцогдоно</h4>
             <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
@@ -607,9 +610,10 @@
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
               <span class="pkg-tier-label">Production</span>
-              <div class="pkg-price">280,000₮<span class="pkg-per"> / хүн</span></div>
+              <div class="pkg-price">280,000₮-аас<span class="pkg-per"> / хүн</span></div>
             </div>
-            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн үйлчилгээний зохион байгуулалт.</p>
+            <p class="pkg-note">Томоохон байгууллагын арга хэмжээнд зориулсан бүрэн зохион байгуулалт.</p>
+            <p class="pkg-note">Энэхүү үнэ нь суурь багцын үнэ бөгөөд арга хэмжээний онцлогоос хамаарч нэмэлт үйлчилгээ тусдаа тооцогдоно.</p>
             <ul class="pkg-features">
               <li>Experience багцын бүх үйлчилгээ</li>
               <li>DJ service (3 цаг)</li>
@@ -623,7 +627,7 @@
               <li>LED дэлгэц 18м²</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <h4 class="pkg-features__sub-title">Тусгайлан тооцоолох үйлчилгээ</h4>
+            <h4 class="pkg-features__sub-title">Тусдаа тооцогдоно</h4>
             <ul class="pkg-features pkg-features--secondary">
               <li>Уран бүтээлч, дуучин, артист, тайзны хөтлөгч</li>
               <li>Захиалгат декор, брэндийн тохижилт болон хэвлэл</li>
@@ -1289,6 +1293,7 @@
       </div>
       <p class="quote-form__message" id="quote-form-message" aria-live="polite"></p>
       <button class="btn btn--accent" type="submit">Урьдчилсан санал авах</button>
+      <p class="quote-form__hint">Бид ажлын 24 цагийн дотор холбогдоно.</p>
     </form>
   </div>
 </div>


### PR DESCRIPTION
Small content consistency fixes based on issue #178 analysis:

- Hero headcount: "30–1000 хүн" → "10–1000 хүн" (subtitle + meta strip)
- Camp card CTAs: "Үнийн санал авах" → "Багц үзэх →"
- Production price: "280,000₮" → "280,000₮-аас" with clarity note
- Production section header: "Тусгайлан тооцоолох үйлчилгээ" → "Тусдаа тооцогдоно"
- Quote form: added response time expectation near submit button

Closes #178

Generated with [Claude Code](https://claude.ai/code)