### PR TITLE
fix: scope camp card/detail toggle to #camps only

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
           <h3>A Кемп</h3>
           <p class="camp-size">200–1000 хүн</p>
           <p>Том хэмжээний байгууллагын арга хэмжээ, өдөрлөг, ойн баярт зориулсан.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-b">
@@ -109,7 +109,7 @@
           <h3>B Кемп</h3>
           <p class="camp-size">50–300 хүн</p>
           <p>Баг, алба нэгжийн сургалт, багийн идэвхжүүлэлт болон дотоод арга хэмжээнд.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-c">
@@ -118,7 +118,7 @@
           <h3>C Кемп</h3>
           <p class="camp-size">10–50 хүн</p>
           <p>Удирдлагын баг, стратегийн уулзалт, төвлөрсөн ажлын хөтөлбөрт.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-mobile">
@@ -127,7 +127,7 @@
           <h3>Нүүдлийн кемп</h3>
           <p class="camp-size">Хүссэн байршилд</p>
           <p>Танай сонгосон байршилд иж бүрэн кемп зохион байгуулна.</p>
-          <span class="camp-card-cta" data-camp-cta>Үнийн санал авах</span>
+          <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
     </div>

--- a/main.js
+++ b/main.js
@@ -521,9 +521,10 @@
   });
 
   // ── CAMP DETAIL TOGGLE ───────────────────────────────────────
-  var campCards = document.querySelectorAll('[data-camp-target]');
+  var campsSection = document.getElementById('camps');
+  var campCards = campsSection ? campsSection.querySelectorAll('[data-camp-target]') : [];
   if (campCards.length > 0) {
-    var campDetails = document.querySelectorAll('.camp-detail');
+    var campDetails = campsSection ? campsSection.querySelectorAll('.camp-detail') : [];
     var resetCampState = function () {
       campCards.forEach(function (card) {
         card.classList.remove('is-active');


### PR DESCRIPTION
Fixes #179

- Scoped `[data-camp-target]` and `.camp-detail` selectors in `main.js` to `#camps` section so the day-program (#midweek) section cannot be affected by camp toggle logic
- Fixed camp card CTA initial text in HTML to "Багц үзэх →" to match the JS reset state

Generated with [Claude Code](https://claude.ai/code)