### PR TITLE
fix: lock Production included service quantities to guest count

### DIFF
--- a/main.js
+++ b/main.js
@@ -814,6 +814,8 @@
       quoteForm.querySelectorAll('.quote-addon-card__sub-options').forEach(function (el) { el.hidden = true; });
       quoteForm.querySelectorAll('.quote-addon-card__quantity').forEach(function (el) { el.hidden = true; });
       quoteForm.querySelectorAll('.quote-addon-card__qty-input').forEach(function (el) { el.disabled = false; });
+      quoteForm.querySelectorAll('.quote-addon-card__qty-text').forEach(function (el) { el.hidden = false; });
+      quoteForm.querySelectorAll('.quote-addon-card__qty-total').forEach(function (el) { el.textContent = '—'; });
       var bartenderPriceEl = document.querySelector('[data-bartender-price]');
       if (bartenderPriceEl) bartenderPriceEl.textContent = '+500,000₮ (1 bartender)';
       var djPriceEl = document.querySelector('[data-dj-price]');
@@ -960,17 +962,25 @@
           }
           var qtyDiv = card.querySelector('.quote-addon-card__quantity');
           if (qtyDiv) {
-            if (tier === 'Production' || cb.dataset.type !== 'per-person') {
+            if (cb.dataset.type !== 'per-person') {
               qtyDiv.hidden = true;
             } else {
-              // Experience included per-person items: show qty div with disabled auto-filled input
+              // Per-person included items: show qty div with disabled auto-filled input
               qtyDiv.hidden = false;
               var qtyInputEl = qtyDiv.querySelector('.quote-addon-card__qty-input');
+              var gNow = guestInput ? (parseInt(guestInput.value, 10) || 0) : 0;
               if (qtyInputEl) {
                 qtyInputEl.disabled = true;
-                var gNow = guestInput ? (parseInt(guestInput.value, 10) || 0) : 0;
+                if (gNow > 0) qtyInputEl.value = gNow;
+              }
+              if (tier === 'Production') {
+                // Lock price display: replace unit-price text with included label
+                var qtyTextEl = qtyDiv.querySelector('.quote-addon-card__qty-text');
+                if (qtyTextEl) qtyTextEl.hidden = true;
+                var totalEl = qtyDiv.querySelector('.quote-addon-card__qty-total');
+                if (totalEl) totalEl.textContent = '· нэмэлт төлбөр авахгүй';
+              } else {
                 if (gNow > 0) {
-                  qtyInputEl.value = gNow;
                   updateQtyTotal(qtyDiv, parseInt(cb.dataset.price, 10), gNow);
                 }
               }
@@ -1448,9 +1458,13 @@
           if (qtyDiv && qtyDiv.hidden) return;
           var unitPrice = cb ? parseInt(cb.dataset.price, 10) : 0;
           if (cb && cb.disabled) {
-            // Experience included per-person items: always track guest count
+            // Included per-person items: always track guest count
             qtyInput.value = g;
-            if (qtyDiv) updateQtyTotal(qtyDiv, unitPrice, g);
+            var currentTier = tierSelect ? tierSelect.value : '';
+            if (currentTier !== 'Production') {
+              if (qtyDiv) updateQtyTotal(qtyDiv, unitPrice, g);
+            }
+            // For Production included items the total stays as "нэмэлт төлбөр авахгүй"
           } else {
             qtyInput.max = g;
             var currentVal = parseInt(qtyInput.value, 10) || 0;

--- a/style.css
+++ b/style.css
@@ -3383,6 +3383,9 @@ body.home-page video {
   color: var(--accent);
 }
 
+/* Ensure [hidden] is respected even when display:flex is set on the element */
+.quote-addon-card__quantity[hidden] { display: none !important; }
+
 /* Tier-included state */
 .quote-addon-card--included {
   background: rgba(40, 140, 60, 0.07);
@@ -3395,6 +3398,16 @@ body.home-page video {
 }
 .quote-addon-card--included .quote-addon-card__price {
   display: none;
+}
+.quote-addon-card--included .quote-addon-card__qty-input:disabled {
+  background: rgba(40, 140, 60, 0.06);
+  color: var(--primary-forest);
+  cursor: not-allowed;
+  border-color: rgba(40, 140, 60, 0.2);
+}
+.quote-addon-card--included .quote-addon-card__qty-total {
+  color: #2a7a3b;
+  font-style: italic;
 }
 .quote-addon-card__included-badge {
   display: inline-block;


### PR DESCRIPTION
Fixes #182

Production tier included service quantities were editable because CSS `display: flex` overrode the HTML `[hidden]` attribute, and the qty input was never disabled.

**Changes:**
- Per-person included items in Production now show a disabled qty input locked to the guest count
- Price text is replaced with "нэмэл төлбөр авахгүй"
- Qty auto-updates when guest count changes
- CSS `[hidden] !important` fix prevents display:flex override
- Modal close resets qty text state

Generated with [Claude Code](https://claude.ai/code)