### PR TITLE
fix: Hide add-ons for C Кемп + Тусгай захиалга quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,6 +970,12 @@
           <span class="quote-field-error" id="err-guests" role="alert" hidden></span>
         </div>
 
+        <!-- C Кемп + Тусгай захиалга: custom order message -->
+        <div class="quote-form__field quote-form__field--full" id="quote-custom-order-msg" hidden>
+          <p class="quote-custom-order__text">Тусгай захиалгын үйлчилгээ нь арга хэмжээний зорилго, оролцогчдын тоо, хөтөлбөр болон нэмэлт хэрэгцээнээс хамаарч тус бүрээр боловсруулагдана.</p>
+          <p class="quote-custom-order__hint">Та шаардлагатай үйлчилгээ, уулзалтын хэлбэр, хоол, тохижилт болон нууцлалын хэрэгцээг тэмдэглэл хэсэгт бичнэ үү.</p>
+        </div>
+
         <!-- ── НЭМЭЛТ ҮЙЛЧИЛГЭЭ ─────────────────────────────────── -->
         <div class="quote-form__field quote-form__field--full quote-addons-wrap" id="quote-addons-section">
           <h3 class="quote-addons__title">Нэмэлт үйлчилгээ (заавал биш)</h3>

--- a/main.js
+++ b/main.js
@@ -758,6 +758,14 @@
 
       // Apply tier inclusions and set qty defaults based on current guest count
       applyTierInclusions(tier);
+
+      // C Кемп + Тусгай захиалга: hide add-ons, show custom order message
+      var isCCustomOrder = (camp === 'C Кемп' && tier === 'Тусгай захиалга');
+      var customOrderMsg = document.getElementById('quote-custom-order-msg');
+      var addonsSection  = document.getElementById('quote-addons-section');
+      if (customOrderMsg) customOrderMsg.hidden = !isCCustomOrder;
+      if (addonsSection)  addonsSection.hidden  = isCCustomOrder;
+
       var currentGuests = guestInput ? (parseInt(guestInput.value, 10) || 0) : 0;
       quoteForm.querySelectorAll('.quote-addon-card__qty-input').forEach(function (qtyInput) {
         var card = qtyInput.closest('.quote-addon-card');
@@ -787,6 +795,11 @@
       if (modalTitleEl) modalTitleEl.textContent = 'Үнийн санал авах';
       applyLocationVisibility('');
       clearAllErrors();
+      // Reset custom order message visibility
+      var customOrderMsgClose = document.getElementById('quote-custom-order-msg');
+      var addonsSectionClose  = document.getElementById('quote-addons-section');
+      if (customOrderMsgClose) customOrderMsgClose.hidden = true;
+      if (addonsSectionClose)  addonsSectionClose.hidden  = false;
       // Reset add-on UI — restore any cards moved to the Production included section
       restoreAddonCardPositions();
       var includedSection = document.getElementById('quote-addons-included-cards');


### PR DESCRIPTION
Fixes #186

For C Кемп + Тусгай захиалга, the quote modal now hides the general add-on selection section and shows a custom order message instead. All other camp/tier combinations are unchanged.

Generated with [Claude Code](https://claude.ai/code)