### PR TITLE
Fix estimate scope: simplified UI only for C Кемп + Тусгай захиалга

### DIFF
--- a/main.js
+++ b/main.js
@@ -1076,6 +1076,15 @@
 
       estimateEl.hidden = false;
 
+      // C Кемп + Тусгай захиалга: simplified estimate — no price breakdown
+      if (camp === 'C Кемп' && tier === 'Тусгай захиалга') {
+        estimateEl.innerHTML =
+          '<p class="quote-estimate__title">Урьдчилсан тооцоолол</p>' +
+          '<p class="quote-estimate__row">Тусгай захиалгын үнийн санал хэлэлцүүлгээр тогтоогдоно.</p>' +
+          '<p class="quote-estimate__disclaimer">Эцсийн үнэ байршил, нэмэлт үйлчилгээнээс хамааран өөрчлөгдөнө.</p>';
+        return;
+      }
+
       var perPerson;
       if (tier === 'Production') {
         perPerson = getProductionPricePerPerson(guests, camp);


### PR DESCRIPTION
Add a strict conditional inside updateEstimate() so the simplified custom-order estimate UI only renders for C Кемп + Тусгай захиалга. All other camps (A, B, Mobile) and other C Camp tiers follow the existing rendering path unchanged.

Closes the scope issue from PR #189.

Generated with [Claude Code](https://claude.ai/code)