### PR TITLE
fix: scope estimate hide strictly to C Кемп + Тусгай захиалга

### DIFF
--- a/main.js
+++ b/main.js
@@ -1074,6 +1074,16 @@
         return;
       }
 
+      // Strict guard: only C Кемп + Тусгай захиалга gets the custom-order treatment
+      if (camp === 'C Кемп' && tier === 'Тусгай захиалга') {
+        estimateEl.hidden = true;
+        var nudgeElC = document.getElementById('tier-nudge');
+        if (nudgeElC) nudgeElC.hidden = true;
+        var prodLinkElC = document.getElementById('production-link');
+        if (prodLinkElC) prodLinkElC.hidden = true;
+        return;
+      }
+
       estimateEl.hidden = false;
 
       var perPerson;


### PR DESCRIPTION
Add explicit strict guard in updateEstimate() so the estimate, nudge, and production link are hidden ONLY when camp === 'C Кемп' && tier === 'Тусгай захиалга'. All other camps and tiers are unaffected.

Closes #190

Generated with [Claude Code](https://claude.ai/code)