### PR TITLE
fix: prevent quote-custom-order-msg from leaking into normal packages

### DIFF
--- a/main.js
+++ b/main.js
@@ -1097,15 +1097,6 @@
 
       estimateEl.hidden = false;
 
-      // C Кемп + Тусгай захиалга: simplified estimate — no price breakdown
-      if (camp === 'C Кемп' && tier === 'Тусгай захиалга') {
-        estimateEl.innerHTML =
-          '<p class="quote-estimate__title">Урьдчилсан тооцоолол</p>' +
-          '<p class="quote-estimate__row">Тусгай захиалгын үнийн санал хэлэлцүүлгээр тогтоогдоно.</p>' +
-          '<p class="quote-estimate__disclaimer">Эцсийн үнэ байршил, нэмэлт үйлчилгээнээс хамааран өөрчлөгдөнө.</p>';
-        return;
-      }
-
       var perPerson;
       if (tier === 'Production') {
         perPerson = getProductionPricePerPerson(guests, camp);

--- a/style.css
+++ b/style.css
@@ -2165,6 +2165,8 @@ body.modal-open { overflow: hidden; }
   display: block;
 }
 .quote-field-error[hidden] { display: none; }
+/* .quote-form__field has display:flex which overrides [hidden] — force it off */
+#quote-custom-order-msg[hidden] { display: none; }
 
 .quote-form input.is-error,
 .quote-form select.is-error,


### PR DESCRIPTION
Fixes #195

## Root Cause

The `#quote-custom-order-msg` element has `display: flex` via its CSS class `.quote-form__field`, which overrides the HTML `hidden` attribute's `display: none` (author class selectors have higher specificity than the UA stylesheet's `[hidden]` rule). Two identical workarounds already existed in the codebase for other elements; this adds the missing third case.

## Changes

- `style.css`: add `#quote-custom-order-msg[hidden] { display: none; }`
- `main.js`: remove unreachable dead code block in `updateEstimate()`

Generated with [Claude Code](https://claude.ai/code)