### PR TITLE
Remove equipment rental accordion from C Кемп Тусгай захиалга card

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,14 +227,6 @@
               <li>Шаардлагатай тохиолдолд орчуулагч / туслах үйлчилгээ</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <div class="pkg-accordion">
-              <button class="pkg-accordion__toggle" type="button" aria-expanded="false">Нэмэлт тоног төхөөрөмжийн түрээс <span class="pkg-accordion__arrow" aria-hidden="true">▾</span></button>
-              <div class="pkg-accordion__body">
-                <p class="pkg-accordion__line">Нэмэлт тоног төхөөрөмжийг M EVENT-с захиалах боломжтой. NOMAAD Кемп захиалагчдад 20% хөнгөлөлттэй.</p>
-                <p class="pkg-accordion__line">→ <a href="https://mevent.mn" target="_blank">mevent.mn</a></p>
-              </div>
-            </div>
-            <div class="pkg-divider" aria-hidden="true"></div>
             <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Тусгай захиалга">Тусгай захиалга авах</a>
           </div>
         </div>


### PR DESCRIPTION
Removes the "Нэмэлт тоног төхөөрөмжийн түрээс" accordion from the C Кемп "Тусгай захиалга" card only. All other package cards are unchanged.

Closes #197

Generated with [Claude Code](https://claude.ai/code)