### PR TITLE
fix: hide add-on sections for Өдрийн хөтөлбөр in quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,6 +968,11 @@
           <p class="quote-custom-order__hint">Та шаардлагатай үйлчилгээ, уулзалтын хэлбэр, хоол, тохижилт болон нууцлалын хэрэгцээг тэмдэглэл хэсэгт бичнэ үү.</p>
         </div>
 
+        <!-- Өдрийн хөтөлбөр: consultative service message (no add-ons) -->
+        <div class="quote-form__field quote-form__field--full" id="quote-day-program-msg" hidden>
+          <p class="quote-custom-order__text">Өдрийн хөтөлбөр нь байгууллагын зорилго, хүний тоо, хөтөлбөрөөс хамаарч тус бүрээр боловсруулагдана.</p>
+        </div>
+
         <!-- ── НЭМЭЛТ ҮЙЛЧИЛГЭЭ ─────────────────────────────────── -->
         <div class="quote-form__field quote-form__field--full quote-addons-wrap" id="quote-addons-section">
           <h3 class="quote-addons__title">Нэмэлт үйлчилгээ (заавал биш)</h3>

--- a/main.js
+++ b/main.js
@@ -768,7 +768,9 @@
       var isCCustomOrder = (camp === 'C Кемп' && tier === 'Тусгай захиалга');
       var customOrderMsg = document.getElementById('quote-custom-order-msg');
       if (customOrderMsg) customOrderMsg.hidden = !isCCustomOrder;
-      if (isCCustomOrder) {
+      var dayProgramMsg = document.getElementById('quote-day-program-msg');
+      if (dayProgramMsg) dayProgramMsg.hidden = !isDayProgram;
+      if (isCCustomOrder || isDayProgram) {
         if (addonsSectionEl && addonsSectionEl.parentNode) addonsSectionEl.parentNode.removeChild(addonsSectionEl);
       } else {
         if (addonsSectionEl && !addonsSectionEl.parentNode && addonsSectionParent) {
@@ -808,6 +810,8 @@
       // Reset custom order message visibility and restore add-ons section to DOM if removed
       var customOrderMsgClose = document.getElementById('quote-custom-order-msg');
       if (customOrderMsgClose) customOrderMsgClose.hidden = true;
+      var dayProgramMsgClose = document.getElementById('quote-day-program-msg');
+      if (dayProgramMsgClose) dayProgramMsgClose.hidden = true;
       if (addonsSectionEl && !addonsSectionEl.parentNode && addonsSectionParent) {
         addonsSectionParent.insertBefore(addonsSectionEl, addonsSectionNextSib);
       }


### PR DESCRIPTION
Fixes #199

When the modal is opened from #midweek (day program section), hide the add-on selection UI and show a consultative service helper message instead. Camp package behavior is unchanged.

Generated with [Claude Code](https://claude.ai/code)