### PR TITLE
fix: explicit quoteMode to separate camp and day-program modal flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="C Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
@@ -209,7 +209,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="C Кемп" data-tier="Experience" data-visual-group="visual_c">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -227,7 +227,7 @@
               <li>Шаардлагатай тохиолдолд орчуулагч / туслах үйлчилгээ</li>
             </ul>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="C Кемп" data-tier="Тусгай захиалга">Тусгай захиалга авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="C Кемп" data-tier="Тусгай захиалга">Тусгай захиалга авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="c" aria-label="C Кемп зургийн цомог">
@@ -272,7 +272,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="B Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
@@ -320,7 +320,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="B Кемп" data-tier="Experience" data-visual-group="visual_b">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -359,7 +359,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="B Кемп" data-tier="Production">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="B Кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="b" aria-label="B Кемп зургийн цомог">
@@ -404,7 +404,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="A Кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
@@ -452,7 +452,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="A Кемп" data-tier="Experience" data-visual-group="visual_a">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -491,7 +491,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="A Кемп" data-tier="Production">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="A Кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="a" aria-label="A Кемп зургийн цомог">
@@ -536,7 +536,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="Нүүдлийн кемп" data-tier="Essential">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--featured" role="listitem">
             <span class="pkg-badge pkg-badge--popular">Хамгийн их сонгогддог</span>
@@ -584,7 +584,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="Нүүдлийн кемп" data-tier="Experience" data-visual-group="visual_mobile">Үнийн санал авах</a>
           </div>
           <div class="pkg-card pkg-card--custom" role="listitem">
             <div class="pkg-header">
@@ -623,7 +623,7 @@
               </div>
             </div>
             <div class="pkg-divider" aria-hidden="true"></div>
-            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Нүүдлийн кемп" data-tier="Production">Үнийн санал авах</a>
+            <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="camp" data-camp-name="Нүүдлийн кемп" data-tier="Production">Үнийн санал авах</a>
           </div>
         </div>
         <div class="camp-gallery" data-camp-gallery="mobile" aria-label="Нүүдлийн кемп зургийн цомог">
@@ -768,7 +768,7 @@
         <div class="pkg-divider" aria-hidden="true"></div>
         <p class="pkg-note">Тохиромжтой арга хэмжээ: HR сургалт, удирдлагын уулзалт, стратегийн төлөвлөлт, борлуулалтын багийн уулзалт, дотоод workshop</p>
         <div class="pkg-divider" aria-hidden="true"></div>
-        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Half Day хөтөлбөр" data-tier="Half Day">Өдрийн хөтөлбөрийн санал авах</a>
+        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="day-program" data-camp-name="Half Day хөтөлбөр" data-tier="Half Day">Өдрийн хөтөлбөрийн санал авах</a>
       </div>
 
       <div class="pkg-card pkg-card--featured" role="listitem">
@@ -791,7 +791,7 @@
         <div class="pkg-divider" aria-hidden="true"></div>
         <p class="pkg-note">Тохиромжтой арга хэмжээ: executive offsite, жилийн төлөвлөлтийн өдөр, sales kickoff, year-end leadership day, founder retreat</p>
         <div class="pkg-divider" aria-hidden="true"></div>
-        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-camp-name="Full Day хөтөлбөр" data-tier="Full Day">Өдрийн хөтөлбөрийн санал авах</a>
+        <a class="btn btn--accent pkg-cta" href="#quote-modal" data-quote-open="true" data-quote-mode="day-program" data-camp-name="Full Day хөтөлбөр" data-tier="Full Day">Өдрийн хөтөлбөрийн санал авах</a>
       </div>
     </div>
 
@@ -970,7 +970,7 @@
 
         <!-- Өдрийн хөтөлбөр: consultative service message (no add-ons) -->
         <div class="quote-form__field quote-form__field--full" id="quote-day-program-msg" hidden>
-          <p class="quote-custom-order__text">Өдрийн хөтөлбөр нь байгууллагын зорилго, хүний тоо, хөтөлбөрөөс хамаарч тус бүрээр боловсруулагдана.</p>
+          <p class="quote-custom-order__text">Өдрийн хөтөлбөр нь Эрдэнэ сум дахь A/B кемп дээр зохион байгуулагдах нэг өдрийн байгууллагын хөтөлбөр бөгөөд байгууллагын зорилго, хүний тоо, хөтөлбөрөөс хамаарч тус бүрээр боловсруулагдана.</p>
         </div>
 
         <!-- ── НЭМЭЛТ ҮЙЛЧИЛГЭЭ ─────────────────────────────────── -->

--- a/main.js
+++ b/main.js
@@ -724,12 +724,13 @@
       quoteModal.setAttribute('aria-hidden', 'false');
       document.body.classList.add('modal-open');
 
+      var quoteMode = (prefill && prefill.quoteMode) || 'camp';
       var camp    = (prefill && prefill.camp)    || '';
       var tier    = (prefill && prefill.tier)    || '';
       var feature = (prefill && prefill.feature) || '';
       var shuttle = (prefill && prefill.shuttle) || 'Сонгохгүй';
 
-      var isDayProgram = DAY_PROGRAM_OPTIONS.indexOf(camp) !== -1;
+      var isDayProgram = (quoteMode === 'day-program');
 
       if (modalTitleEl) {
         if (isDayProgram) {
@@ -1517,6 +1518,7 @@
     quoteOpeners.forEach(function (link) {
       link.addEventListener('click', function (e) {
         e.preventDefault();
+        var quoteMode   = (link.dataset.quoteMode   || 'camp').trim();
         var campName    = (link.dataset.campName    || '').trim();
         var tier        = (link.dataset.tier        || '').trim();
         var visualGroup = (link.dataset.visualGroup || '').trim();
@@ -1525,7 +1527,7 @@
           var checked = document.querySelector('input[name="' + visualGroup + '"]:checked');
           feature = checked ? checked.value : '';
         }
-        openQuoteModal(campName || tier ? { camp: campName, tier: tier, feature: feature, shuttle: 'Сонгохгүй' } : null);
+        openQuoteModal({ quoteMode: quoteMode, camp: campName, tier: tier, feature: feature, shuttle: 'Сонгохгүй' });
       });
     });
 


### PR DESCRIPTION
Fixes #201

Introduces an explicit `data-quote-mode` attribute on every quote CTA button ("camp" or "day-program") and makes `openQuoteModal` derive `isDayProgram` from that explicit attribute instead of inferring it from the camp name string.

Generated with [Claude Code](https://claude.ai/code)