### PR TITLE
fix: separate camp and day-program quote modal state to prevent leakage

### DIFF
--- a/main.js
+++ b/main.js
@@ -731,6 +731,7 @@
       var shuttle = (prefill && prefill.shuttle) || 'Сонгохгүй';
 
       var isDayProgram = (quoteMode === 'day-program');
+      quoteModal.dataset.quoteMode = quoteMode;
 
       if (modalTitleEl) {
         if (isDayProgram) {
@@ -803,8 +804,17 @@
       document.body.classList.remove('modal-open');
       if (contextHint) contextHint.hidden = true;
       if (estimateEl) estimateEl.hidden = true;
+      var nudgeElClose = document.getElementById('tier-nudge');
+      if (nudgeElClose) nudgeElClose.hidden = true;
+      var prodLinkElClose = document.getElementById('production-link');
+      if (prodLinkElClose) prodLinkElClose.hidden = true;
+      var tierSuccessElClose = document.getElementById('tier-success');
+      if (tierSuccessElClose) { tierSuccessElClose.classList.remove('fade-out'); tierSuccessElClose.hidden = true; }
       if (campSelect) campSelect.value = '';
       if (tierSelect) tierSelect.value = '';
+      if (guestInput) guestInput.value = '';
+      if (shuttleSelect) shuttleSelect.value = 'Сонгохгүй';
+      quoteModal.removeAttribute('data-quote-mode');
       if (modalTitleEl) modalTitleEl.textContent = 'Үнийн санал авах';
       applyLocationVisibility('');
       clearAllErrors();
@@ -1076,6 +1086,10 @@
 
     function updateEstimate() {
       if (!estimateEl) return;
+      if (quoteModal.dataset.quoteMode === 'day-program') {
+        estimateEl.hidden = true;
+        return;
+      }
       var camp    = campSelect    ? campSelect.value               : '';
       var tier    = tierSelect    ? tierSelect.value               : '';
       var guests  = guestInput    ? parseInt(guestInput.value, 10) : 0;
@@ -1107,9 +1121,23 @@
         perPerson = getProductionPricePerPerson(guests, camp);
       } else {
         var campPrices = PRICE_TABLE[tier];
-        if (!campPrices) { estimateEl.hidden = true; return; }
+        if (!campPrices) {
+          estimateEl.hidden = true;
+          var nudgeElMiss = document.getElementById('tier-nudge');
+          if (nudgeElMiss) nudgeElMiss.hidden = true;
+          var prodLinkElMiss = document.getElementById('production-link');
+          if (prodLinkElMiss) prodLinkElMiss.hidden = true;
+          return;
+        }
         perPerson = campPrices[camp];
-        if (!perPerson) { estimateEl.hidden = true; return; }
+        if (!perPerson) {
+          estimateEl.hidden = true;
+          var nudgeElMiss2 = document.getElementById('tier-nudge');
+          if (nudgeElMiss2) nudgeElMiss2.hidden = true;
+          var prodLinkElMiss2 = document.getElementById('production-link');
+          if (prodLinkElMiss2) prodLinkElMiss2.hidden = true;
+          return;
+        }
       }
 
       var base = perPerson * guests;


### PR DESCRIPTION
Fixes #203

## Root Causes

1. `quoteMode` was a local variable in `openQuoteModal` and never stored on the modal element, so event handlers like `updateEstimate` could not guard against day-program mode.
2. `closeQuoteModal` did not reset `tier-nudge`, `production-link`, `tier-success`, `guestInput.value`, or `shuttleSelect.value` — all leaked from camp into day-program.
3. `updateEstimate` had no `quoteMode` guard — only accidentally hidden by a missing PRICE_TABLE entry.
4. PRICE_TABLE early-return paths did not hide `tier-nudge` / `production-link`.

## Changes

- `openQuoteModal`: stores `quoteMode` on `quoteModal.dataset.quoteMode`
- `closeQuoteModal`: resets all state (nudge, production-link, success banner, guest count, shuttle)
- `updateEstimate`: explicit early return for day-program mode
- `updateEstimate`: PRICE_TABLE early-return paths now also hide nudge and production-link

Generated with [Claude Code](https://claude.ai/code)