### PR TITLE
fix: prevent day-program text from showing in camp quote modal

### DIFF
--- a/style.css
+++ b/style.css
@@ -2167,6 +2167,7 @@ body.modal-open { overflow: hidden; }
 .quote-field-error[hidden] { display: none; }
 /* .quote-form__field has display:flex which overrides [hidden] — force it off */
 #quote-custom-order-msg[hidden] { display: none; }
+#quote-day-program-msg[hidden]  { display: none; }
 
 .quote-form input.is-error,
 .quote-form select.is-error,


### PR DESCRIPTION
Fixes #208

The `.quote-form__field` class uses `display: flex`, which overrides the HTML `hidden` attribute. A CSS override already existed for `#quote-custom-order-msg` but was missing for `#quote-day-program-msg`, causing the Өдрийн хөтөлбөр text to appear in camp modals.

Added one line to `style.css`:
`#quote-day-program-msg[hidden] { display: none; }`

Generated with [Claude Code](https://claude.ai/code)