### PR TITLE
fix: prevent camp estimate bleeding into day-program modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -803,7 +803,7 @@
       quoteModal.setAttribute('aria-hidden', 'true');
       document.body.classList.remove('modal-open');
       if (contextHint) contextHint.hidden = true;
-      if (estimateEl) estimateEl.hidden = true;
+      if (estimateEl) { estimateEl.hidden = true; estimateEl.innerHTML = ''; }
       var nudgeElClose = document.getElementById('tier-nudge');
       if (nudgeElClose) nudgeElClose.hidden = true;
       var prodLinkElClose = document.getElementById('production-link');
@@ -1090,6 +1090,7 @@
       var prodLinkEl = document.getElementById('production-link');
       if (quoteModal.dataset.quoteMode === 'day-program') {
         estimateEl.hidden = true;
+        estimateEl.innerHTML = '';
         if (nudgeEl)    nudgeEl.hidden    = true;
         if (prodLinkEl) prodLinkEl.hidden = true;
         return;

--- a/style.css
+++ b/style.css
@@ -2168,6 +2168,7 @@ body.modal-open { overflow: hidden; }
 /* .quote-form__field has display:flex which overrides [hidden] — force it off */
 #quote-custom-order-msg[hidden] { display: none; }
 #quote-day-program-msg[hidden]  { display: none; }
+#quote-estimate[hidden]         { display: none; }
 
 .quote-form input.is-error,
 .quote-form select.is-error,


### PR DESCRIPTION
Fixes #210

CSS `display:flex` on `.quote-estimate` overrode the `[hidden]` attribute, so `estimateEl.hidden = true` never actually hid the element. Added `#quote-estimate[hidden] { display: none }` to match the existing guard pattern used for `#quote-custom-order-msg` and `#quote-day-program-msg`. Also clears `estimateEl.innerHTML` on close and in the day-program guard as belt-and-suspenders.

Generated with [Claude Code](https://claude.ai/code)