### PR TITLE
fix: prevent tier-nudge and production-link bleeding into day-program modal

### DIFF
--- a/style.css
+++ b/style.css
@@ -2165,10 +2165,12 @@ body.modal-open { overflow: hidden; }
   display: block;
 }
 .quote-field-error[hidden] { display: none; }
-/* .quote-form__field has display:flex which overrides [hidden] — force it off */
+/* display:flex on these elements overrides [hidden] — force it off */
 #quote-custom-order-msg[hidden] { display: none; }
 #quote-day-program-msg[hidden]  { display: none; }
 #quote-estimate[hidden]         { display: none; }
+#tier-nudge[hidden]             { display: none; }
+#production-link[hidden]        { display: none; }
 
 .quote-form input.is-error,
 .quote-form select.is-error,


### PR DESCRIPTION
Fixes follow-up issue from #211

`.quote-tier-nudge` and `.quote-production-link` both have `display:flex` which overrides the `[hidden]` attribute, so hiding them via JS never actually removed them visually. Added `[hidden]` overrides following the same guard pattern used for `#quote-estimate`, `#quote-custom-order-msg`, and `#quote-day-program-msg`.

Generated with [Claude Code](https://claude.ai/code)