### PR TITLE
fix: include LED дэлгэц 18м² in Нүүдлийн кемп Production package

### DIFF
--- a/main.js
+++ b/main.js
@@ -920,8 +920,7 @@
 
     function getTierInclusions(campName, tier) {
       var included = TIER_INCLUSIONS[tier] ? TIER_INCLUSIONS[tier].slice() : [];
-      if (tier === 'Production' &&
-          (campName === 'C Кемп' || campName === 'Нүүдлийн кемп')) {
+      if (tier === 'Production' && campName === 'C Кемп') {
         included = included.filter(function (item) { return item !== 'led_screen_18m2'; });
       }
       return included;


### PR DESCRIPTION
## Summary

- `getTierInclusions` was incorrectly filtering `led_screen_18m2` out for both C Кемп and Нүүдлийн кемп
- Removed Нүүдлийн кемп from the filter so LED дэлгэц 18м² now appears as an included service (not an optional add-on) for that camp
- C Кемп, A Кемп, B Кемп, and Day Program are untouched

Closes #216

Generated with [Claude Code](https://claude.ai/code)