### PR TITLE
Show add-on services in day program quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -959,7 +959,7 @@
           <p class="quote-custom-order__hint">Та шаардлагатай үйлчилгээ, уулзалтын хэлбэр, хоол, тохижилт болон нууцлалын хэрэгцээг тэмдэглэл хэсэгт бичнэ үү.</p>
         </div>
 
-        <!-- Өдрийн хөтөлбөр: consultative service message (no add-ons) -->
+        <!-- Өдрийн хөтөлбөр: consultative service message -->
         <div class="quote-form__field quote-form__field--full" id="quote-day-program-msg" hidden>
           <p class="quote-custom-order__text">Өдрийн хөтөлбөр нь Эрдэнэ сум дахь A/B кемп дээр зохион байгуулагдах бөгөөд байгууллагын зорилго, хүний тоо, хөтөлбөрөөс хамаарч тус бүрээр боловсруулагдана.</p>
         </div>

--- a/main.js
+++ b/main.js
@@ -767,12 +767,13 @@
       applyTierInclusions(tier);
 
       // C Кемп + Тусгай захиалга: remove add-ons from DOM entirely, show custom order message
+      // Өдрийн хөтөлбөр дээр нэмэлт үйлчилгээ харагдана (кемпүүдтэй ижил).
       var isCCustomOrder = (camp === 'C Кемп' && tier === 'Тусгай захиалга');
       var customOrderMsg = document.getElementById('quote-custom-order-msg');
       if (customOrderMsg) customOrderMsg.hidden = !isCCustomOrder;
       var dayProgramMsg = document.getElementById('quote-day-program-msg');
       if (dayProgramMsg) dayProgramMsg.hidden = !isDayProgram;
-      if (isCCustomOrder || isDayProgram) {
+      if (isCCustomOrder) {
         if (addonsSectionEl && addonsSectionEl.parentNode) addonsSectionEl.parentNode.removeChild(addonsSectionEl);
       } else {
         if (addonsSectionEl && !addonsSectionEl.parentNode && addonsSectionParent) {


### PR DESCRIPTION
### Motivation
- Ensure the quote modal for the `day-program` mode shows optional add-on services in the same place as camp quotes so extras appear above the shuttle/transport selector. 
- Fix a UI logic mismatch where add-ons were previously removed for day programs even though pricing and ordering should match the camp flow.

### Description
- Update `main.js` to only remove the add-ons DOM section for `C Кемп + Тусгай захиалга` by changing the removal condition from `(isCCustomOrder || isDayProgram)` to `isCCustomOrder`, preserving add-ons for `day-program` mode. 
- Add a clarifying comment in `main.js` noting that add-ons are visible for day programs. 
- Update the HTML comment in `index.html` for the `quote-day-program-msg` block to reflect that day programs are consultative but do allow add-ons.

### Testing
- No automated tests were run for this change; the edit was verified by inspecting the diffs for `main.js` and `index.html` and confirming the updated conditional logic and comments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45a2da0ac832183c98fef9b98e150)