### PR TITLE
Remove 'client brings own alcohol/juice' note from Moonbeam Lounge

### DIFF
--- a/index.html
+++ b/index.html
@@ -1187,9 +1187,6 @@
                   <span class="quote-addon-card__detail">
                     Гэрэлтдэг bar тек, ambient lighting, premium glassware
                   </span>
-                  <span class="quote-addon-card__client-supplied">
-                    Алкохол, жүүс, орц материалыг хэрэглэгч авч ирнэ
-                  </span>
                   <span class="quote-addon-card__price">+500,000₮</span>
                 </div>
               </label>


### PR DESCRIPTION
Moonbeam Lounge хэсгээс "Алкохол, жүүс, орц материалыг хэрэглэгч авч ирнэ" тэмдэглэлийг хасав. Энэ тэмдэглэл Bartender service хэсгээс л байх естой байсан.

Related to #226

Generated with [Claude Code](https://claude.ai/code)