### PR TITLE
feat: Experience tier — show 'нэмэлт төлбөр авахгүй' section in quote modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -972,9 +972,9 @@
           <h3 class="quote-addons__title">Нэмэлт үйлчилгээ (заавал биш)</h3>
           <p class="quote-addons__subtitle">Хэрэгцээтэй сонгож, үндсэн багц дээр нэмж захиалаарай</p>
 
-          <!-- Production: included cards section (shown only when Production tier is selected) -->
+          <!-- Production/Experience: included cards section (shown when Production or Experience tier is selected) -->
           <div class="quote-addons__group quote-addons__group--included-cards" id="quote-addons-included-cards" hidden>
-            <h4 class="quote-addons__group-title quote-addons__group-title--included">Production багцад багтсан үйлчилгээ</h4>
+            <h4 class="quote-addons__group-title quote-addons__group-title--included" id="quote-addons-included-title">Production багцад багтсан үйлчилгээ</h4>
             <p class="quote-addons__included-desc">Эдгээр үйлчилгээ таны багцад аль хэдийн багтсан — нэмэлт төлбөр авахгүй</p>
             <div class="quote-addons__grid" id="quote-addons-included-grid"></div>
             <ul class="quote-production-included-list">

--- a/main.js
+++ b/main.js
@@ -976,8 +976,8 @@
       var titlePerPerson   = document.getElementById('quote-addons-title-per-person');
       var titleFlat        = document.getElementById('quote-addons-title-flat');
 
-      // For non-Production tiers, restore cards to original positions and hide Production UI
-      if (tier !== 'Production') {
+      // For non-Production/non-Experience tiers, restore cards to original positions and hide included UI
+      if (tier !== 'Production' && tier !== 'Experience') {
         restoreAddonCardPositions();
         if (includedSection) includedSection.hidden = true;
         if (optionalLabel)   optionalLabel.hidden   = true;
@@ -1002,8 +1002,8 @@
             var nameEl = card.querySelector('.quote-addon-card__name');
             if (nameEl) nameEl.appendChild(badge);
           }
-          // Move included cards into the Production section grid
-          if (tier === 'Production' && includedGrid) {
+          // Move included cards into the included section grid
+          if ((tier === 'Production' || tier === 'Experience') && includedGrid) {
             includedGrid.appendChild(card);
           }
           var qtyDiv = card.querySelector('.quote-addon-card__quantity');
@@ -1019,7 +1019,7 @@
                 qtyInputEl.disabled = true;
                 if (gNow > 0) qtyInputEl.value = gNow;
               }
-              if (tier === 'Production') {
+              if (tier === 'Production' || tier === 'Experience') {
                 // Lock price display: replace unit-price text with included label
                 var qtyTextEl = qtyDiv.querySelector('.quote-addon-card__qty-text');
                 if (qtyTextEl) qtyTextEl.hidden = true;
@@ -1046,7 +1046,11 @@
         }
       });
 
-      if (tier === 'Production') {
+      if (tier === 'Production' || tier === 'Experience') {
+        var includedTitleEl = document.getElementById('quote-addons-included-title');
+        if (includedTitleEl) includedTitleEl.textContent = tier + ' багцад багтсан үйлчилгээ';
+        var productionList = document.querySelector('.quote-production-included-list');
+        if (productionList) productionList.hidden = (tier !== 'Production');
         if (includedSection) includedSection.hidden = false;
         if (optionalLabel)   optionalLabel.hidden   = false;
         // Hide original group titles — the new section labels replace them


### PR DESCRIPTION
Closes #227

Adds the same 'нэмэлт төлбөр авахгүй' included-cards section to the Experience tier that already existed for Production.

Generated with [Claude Code](https://claude.ai/code)