### PR TITLE
fix: Experience багцанд хүний тоо оруулахад үнэ гарах алдаа засах

### DIFF
--- a/main.js
+++ b/main.js
@@ -1582,10 +1582,10 @@
             // Included per-person items: always track guest count
             qtyInput.value = g;
             var currentTier = tierSelect ? tierSelect.value : '';
-            if (currentTier !== 'Production') {
+            if (currentTier !== 'Production' && currentTier !== 'Experience') {
               if (qtyDiv) updateQtyTotal(qtyDiv, unitPrice, g);
             }
-            // For Production included items the total stays as "нэмэлт төлбөр авахгүй"
+            // For Production/Experience included items the total stays as "нэмэлт төлбөр авахгүй"
           } else {
             qtyInput.max = g;
             var currentVal = parseInt(qtyInput.value, 10) || 0;


### PR DESCRIPTION
Experience багц сонгогдсон үед addon картууд хүний тоо оруулахад '· нөмөр тайлбар авахгүй' гэж гарах ёстой байсан гэвч төлбөр гарагддаг байлаа.

Closes #230

Generated with [Claude Code](https://claude.ai/code)