### PR TITLE
Update camp card descriptions to state style with capacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,7 @@
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="NOMAAD Summit" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="a">
         <div class="camp-card-body">
           <h3>NOMAAD Summit</h3>
-          <p class="camp-size">200–1000 хүн</p>
-          <p>Уулын оройд байрлах, өргөн уужим орчинтой кемп</p>
+          <p>Уулын оройд байрлах, өргөн уужим орчинтой кемп · 1000 хүн хүртэл</p>
           <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
@@ -107,8 +106,7 @@
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="NOMAAD Meadow" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="b">
         <div class="camp-card-body">
           <h3>NOMAAD Meadow</h3>
-          <p class="camp-size">50–300 хүн</p>
-          <p>Ойн захад байрлах, нээлттэй ба нөмөр орчин хосолсон кемп</p>
+          <p>Ойн захад байрлах, харууц ба нөмөр орчин хосолсон кемп · 300 хүн хүртэл</p>
           <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
@@ -116,17 +114,15 @@
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="NOMAAD Grove" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="c">
         <div class="camp-card-body">
           <h3>NOMAAD Grove</h3>
-          <p class="camp-size">10–50 хүн</p>
-          <p>Ойн дунд байрлах, 360° модоор хүрээлэгдсэн тайван кемп</p>
+          <p>Ойн дунд байрлах, 360° модоор хүрээлэгдсэн тайван кемп · 200 хүн хүртэл</p>
           <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>
       <button class="camp-card" type="button" data-camp-target="camp-mobile">
-        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="Нүүдлийн кемп" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="mobile">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='%23EAE3D5'/%3E%3C/svg%3E" alt="NOMAAD Mobile" loading="lazy" decoding="async" class="defer-img" data-camp-thumb="mobile">
         <div class="camp-card-body">
-          <h3>Нүүдлийн кемп</h3>
-          <p class="camp-size">Хүссэн байршилд</p>
-          <p>Танай сонгосон байршилд иж бүрэн кемп зохион байгуулна.</p>
+          <h3>NOMAAD Mobile</h3>
+          <p>Хүссэн байршилд, иж бүрэн кемп · 1000 хүн хүртэл</p>
           <span class="camp-card-cta" data-camp-cta>Багц үзэх →</span>
         </div>
       </button>


### PR DESCRIPTION
Update camp card descriptions to use state/environment language and merge capacity inline with · separator.

Related to #233

Generated with [Claude Code](https://claude.ai/code)