### PR TITLE
Fix camp card default state: remove hardcoded is-open from Summit

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
         </div>
       </article>
 
-      <article class="camp-detail has-packages is-open" id="camp-a">
+      <article class="camp-detail has-packages" id="camp-a">
         <div class="camp-detail-text">
           <h3>NOMAAD Summit · 200–1000 хүн</h3>
           <p>Уулын оройд байрлах, өргөн уужим орчинтой кемп</p>


### PR DESCRIPTION
Removes hardcoded `is-open` class from the Summit camp detail article so all cards start closed on page load.

Related to #234

Generated with [Claude Code](https://claude.ai/code)