### PR TITLE
fix: revert CNAME to nomaadcamp.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-nomaadcamp.mn
+nomaadcamp.com


### PR DESCRIPTION
Reverts the CNAME change from PR #243 back to nomaadcamp.com (was incorrectly changed to nomaadcamp.mn).

Generated with [Claude Code](https://claude.ai/code)