### PR TITLE
fix: replace nomaadcamp.mn URLs with nomaadcamp.com in meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,18 +9,18 @@
 <link rel="mask-icon" href="favicon.svg" color="#2F3E2F">
 <meta name="theme-color" content="#2F3E2F">
 <meta name="robots" content="index,follow">
-<link rel="canonical" href="https://nomaadcamp.mn/">
+<link rel="canonical" href="https://nomaadcamp.com/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="NOMAAD Camp — Байгууллагын арга хэмжээний бүрэн зохион байгуулалт">
 <meta property="og:description" content="Байгууллагын арга хэмжээ, багийн идэвхжүүлэлт, удирдлагын уулзалт, том хэмжээний эвентийг төлөвлөлтөөс гүйцэтгэл хүртэл нэгдсэн байдлаар хэрэгжүүлнэ.">
-<meta property="og:url" content="https://nomaadcamp.mn/">
-<meta property="og:image" content="https://nomaadcamp.mn/images/camps/a-camp/cover/A-01.jpg">
+<meta property="og:url" content="https://nomaadcamp.com/">
+<meta property="og:image" content="https://nomaadcamp.com/images/camps/a-camp/cover/A-01.jpg">
 <meta property="og:site_name" content="NOMAAD Camp">
 <meta property="og:locale" content="mn_MN">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NOMAAD Camp | Байгууллагын арга хэмжээний нэгдсэн шийдэл">
 <meta name="twitter:description" content="Байгууллагын арга хэмжээг кемп, катеринг, техник, хөтөлбөрийн гүйцэтгэлтэй нь нэгдсэн байдлаар зохион байгуулна.">
-<meta name="twitter:image" content="https://nomaadcamp.mn/images/camps/a-camp/cover/A-01.jpg">
+<meta name="twitter:image" content="https://nomaadcamp.com/images/camps/a-camp/cover/A-01.jpg">
 <link rel="preload" href="style.css" as="style">
 <link rel="stylesheet" href="style.css">
 <link rel="preload" as="image" href="/images/hero/gallery-05.jpg" fetchpriority="high">


### PR DESCRIPTION
Fixes domain mismatch in index.html by updating canonical, og:url, og:image, and twitter:image meta tags to use nomaadcamp.com instead of nomaadcamp.mn, matching the live domain set in CNAME.

Related to #244

Generated with [Claude Code](https://claude.ai/code)