### PR TITLE
Add Google Analytics GA4 tracking (G-9BX36FS624)

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,15 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Inter+Tight:wght@600;700&family=Manrope:wght@500;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Inter+Tight:wght@600;700&family=Manrope:wght@500;700;800&display=swap"></noscript>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-9BX36FS624"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-9BX36FS624');
+</script>
 </head>
 <body class="home-page">
 <a class="skip-link" href="#main-content">Үндсэн контент руу алгасах</a>


### PR DESCRIPTION
Inserts the GA4 gtag.js snippet into the `<head>` of `index.html` just before the closing tag.

Closes #248

Generated with [Claude Code](https://claude.ai/code)